### PR TITLE
Added tf-import weblet

### DIFF
--- a/src/elements/Import/Import.wc.svelte
+++ b/src/elements/Import/Import.wc.svelte
@@ -1,0 +1,36 @@
+<svelte:options tag={null} />
+
+<script lang="ts">
+  import { parse } from "marked";
+  import { onMount } from "svelte";
+
+  export let path: string;
+
+  let html: string;
+  let loading: boolean = true;
+
+  onMount(() => {
+    fetch(path)
+      .then((res) => res.text())
+      .then((md) => {
+        return parse(md, {
+          sanitize: false,
+        });
+      })
+      .then((_) => (html = _))
+      .catch((err) => console.log("Error", err))
+      .finally(() => (loading = false));
+  });
+</script>
+
+{#if loading}
+  <p style="text-align: center;">Loading page content.</p>
+{:else if html}
+  {@html html}
+{:else}
+  <p style="text-align: center;">Failed to load page content.</p>
+{/if}
+
+<style lang="scss" scoped>
+  @import url("https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css");
+</style>

--- a/src/elements/Import/index.ts
+++ b/src/elements/Import/index.ts
@@ -1,0 +1,4 @@
+import Import from "./Import.wc.svelte";
+import defineElement from "../../utils/defineElement";
+
+defineElement("import", Import);


### PR DESCRIPTION
## TF Import
tf-import enables you to import almost any `markdown` parsable file  including `.md - .html - .htm`

### Example
```html
<tf-import path="https://raw.githubusercontent.com/threefoldtech/tfchain_explorer/master/README.md"></tf-import>
```

```html
<div style="width: 500px; height: 500px; overflow: auto;">
    <tf-import path="https://raw.githubusercontent.com/threefoldtech/tfchain_explorer/master/README.md"></tf-import>
</div>
```

