### PR TITLE
Renaming profile deactivate button

### DIFF
--- a/src/elements/profiles/Profiles.wc.svelte
+++ b/src/elements/profiles/Profiles.wc.svelte
@@ -170,7 +170,7 @@
                 configs.setActiveProfile(null, password);
               }}
             >
-              Back
+              Deactivate
             </button>
           </div>
         {/if}


### PR DESCRIPTION
### Description

- Renaming the Profile deactivate button from `Back` to `Deactivate`.

### Changes

### Related Issues
- fixes #156 

