### PR TITLE
Setting Env var default values to empty string

### DIFF
--- a/src/types/vm.ts
+++ b/src/types/vm.ts
@@ -6,8 +6,8 @@ import NodeID from "./nodeId";
 export class Env {
   constructor(
     public id = v4(),
-    public key = "SSH_KEY",
-    public value = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTwULSsUubOq3VPWL6cdrDvexDmjfznGydFPyaNcn7gAL9lRxwFbCDPMj7MbhNSpxxHV2+/iJPQOTVJu4oc1N7bPP3gBCnF51rPrhTpGCt5pBbTzeyNweanhedkKDsCO2mIEh/92Od5Hg512dX4j7Zw6ipRWYSaepapfyoRnNSriW/s3DH/uewezVtL5EuypMdfNngV/u2KZYWoeiwhrY/yEUykQVUwDysW/xUJNP5o+KSTAvNSJatr3FbuCFuCjBSvageOLHePTeUwu6qjqe+Xs4piF1ByO/6cOJ8bt5Vcx0bAtI8/MPApplUU/JWevsPNApvnA/ntffI+u8DCwgP"
+    public key = "",
+    public value = ""
   ) {}
 
   public get valid(): boolean {


### PR DESCRIPTION
### Description

- now newly added env vars no longer have a hardcoded default value described in the issue, the key and the value are default to empty string

### Changes

### Related Issues
fixes #190 

