### PR TITLE
add link for docs in caprover weblet

### DIFF
--- a/src/elements/caprover/Caprover.wc.svelte
+++ b/src/elements/caprover/Caprover.wc.svelte
@@ -89,6 +89,14 @@
 <div style="padding: 15px;">
   <form class="box" on:submit|preventDefault={deployCaproverHandler}>
     <h4 class="is-size-4 mb-4">Caprover Deployer</h4>
+    <p>
+      <a
+        target="_blank"
+        href="https://library.threefold.me/info/manual/#/manual__weblets_caprover"
+      >
+        Quick start documentation</a
+      >
+    </p>
     <hr />
 
     {#if loading}


### PR DESCRIPTION
### Description

add link for docs in caprover weblet

### Changes

![Screenshot from 2021-12-16 15-38-35](https://user-images.githubusercontent.com/10658229/146382766-ef80ba43-002d-4820-96e7-78c72ffe777a.png)

### Related Issues

- https://github.com/threefoldtech/grid_weblets/issues/197

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
