### PR TITLE
Adding regex domain name validator

### DIFF
--- a/src/elements/caprover/Caprover.wc.svelte
+++ b/src/elements/caprover/Caprover.wc.svelte
@@ -17,6 +17,7 @@
   import Modal from "../../components/DeploymentModal.svelte";
   import hasEnoughBalance from "../../utils/hasEnoughBalance";
   import validateName from "../../utils/validateName";
+import validateDomainName from "../../utils/validateDomainName";
 
   const data = new Caprover();
   let loading = false;
@@ -39,11 +40,11 @@
     { label: "CPU", symbol: "cpu", placeholder: "CPU", type: "number" },
     { label: "Memory (MB)", symbol: 'memory', placeholder: "Memory in MB", type: "number" },
     { label: "Disk Size (GB)", symbol: "diskSize", placeholder: "Disk size in GB", type: "number" },
-    { label: "Domain", symbol: "domain", placeholder: "domain configured in your name provider.", type: "text" },
+    { label: "Domain", symbol: "domain", placeholder: "domain configured in your name provider.", type: "text", validator: validateDomainName, invalid: false },
     { label: "Password", symbol: "password", placeholder: "Caprover new password", type: "text" },
   ];
 
-  $: disabled = ((loading || !data.valid) && !(success || failed)) || !profile || status !== "valid" || fields[0].invalid; // prettier-ignore
+  $: disabled = ((loading || !data.valid) && !(success || failed)) || !profile || status !== "valid" || fields[0].invalid || fields[4].invalid; // prettier-ignore
   let message: string;
   let modalData: Object;
   async function deployCaproverHandler() {

--- a/src/utils/validateDomainName.ts
+++ b/src/utils/validateDomainName.ts
@@ -1,0 +1,7 @@
+// regex pattern for validating domain name
+const DOMAIN_NAME_REGEX = /^\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,6}\b$/
+
+// prettier-ignore
+export default function validateDomainName(domain: string): string | void {
+    if (!DOMAIN_NAME_REGEX.test(domain)) return "this is not like a valid domain name";
+}

--- a/src/utils/validateDomainName.ts
+++ b/src/utils/validateDomainName.ts
@@ -1,7 +1,7 @@
-// regex pattern for validating domain name
-const DOMAIN_NAME_REGEX = /^\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,6}\b$/
+// regex patter for validating domain name
+const DOMAIN_NAME_REGEX = /^\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}\b$/
 
 // prettier-ignore
 export default function validateDomainName(domain: string): string | void {
-    if (!DOMAIN_NAME_REGEX.test(domain)) return "this is not like a valid domain name";
+    if (!DOMAIN_NAME_REGEX.test(domain)) return "Domain name is not valid";
 }


### PR DESCRIPTION
### Description

adding a domain name validator with the below specification
- each part of the domain should be no longer than 63 characters
- the domain name should be a-z or A-Z or 0-9 and hyphen, but hyphen not allowed at the beginning or the end of the domain.
- domain name couldn't be less than one character, and TLD couldn't be less than two character
- allow internationalized domain names using the punycode notation `xn--`

Limitation:
only English language domain names allowed atm
 
I was looking for an equal for\p{L} and \p{Nd}  in JavaScript Regex that matches any kind of letter and numbers from any language but wasn't able to find

### Related Issues

#206 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
