### PR TITLE
Adding extra field description for CapRover root domain

### DIFF
--- a/src/elements/caprover/Caprover.wc.svelte
+++ b/src/elements/caprover/Caprover.wc.svelte
@@ -126,7 +126,6 @@
           {/if}
           {#if field.symbol === "domain"}
             <div class="notification is-warning is-light">
-              <strong>Note:</strong>
               <p>
                 You will need to point a wildcard DNS entry for the domain you
                 entered above to this CapRover instance IP Address after

--- a/src/elements/caprover/Caprover.wc.svelte
+++ b/src/elements/caprover/Caprover.wc.svelte
@@ -124,6 +124,28 @@
           {:else}
             <Input bind:data={data[field.symbol]} {field} />
           {/if}
+          {#if field.symbol === "domain"}
+            <div class="notification is-warning is-light">
+              <strong>Note:</strong>
+              <p>
+                You will need to point a wildcard DNS entry for the domain you
+                entered above to this CapRover instance IP Address after
+                deployment,<br />
+                otherwise, you won't be able to access the CapRover dashboard using
+                this domain.
+              </p>
+              <br />
+              <strong>
+                If you don't know what Captain root domain is, make sure to
+                visit <a
+                  target="_blank"
+                  href="https://library.threefold.me/info/manual/#/manual__weblets_caprover"
+                >
+                  the Quick start documentation
+                </a>.
+              </strong>
+            </div>
+          {/if}
         {/each}
         <SelectNodeId
           cpu={data.cpu}


### PR DESCRIPTION
Adding extra field description for CapRover root domain

![Screenshot from 2021-12-20 16-11-25](https://user-images.githubusercontent.com/42457449/146780250-f79a6742-c0c6-4007-a040-9d0eee7ce0cd.png)

### Related Issues
https://github.com/threefoldtech/grid_weblets/issues/291
