### PR TITLE
Using vue-cli-plugin-compression

### DIFF
--- a/easy-docs/package.json
+++ b/easy-docs/package.json
@@ -20,6 +20,7 @@
     "ts-rmb-http-client": "^0.1.9",
     "vue": "^2.6.11",
     "vue-class-component": "^7.2.3",
+    "vue-cli-plugin-compression": "^1.1.5",
     "vue-property-decorator": "^9.1.2",
     "vue-router": "^3.2.0",
     "vuex": "^3.4.0"

--- a/easy-docs/vue.config.js
+++ b/easy-docs/vue.config.js
@@ -1,9 +1,31 @@
 const { join } = require("path");
+const zlib = require("zlib");
 
 module.exports = {
     transpileDependencies: [
       'vuetify'
     ],
     outputDir: join(__dirname, '..', 'docs'),
-    publicPath: '/'
+    publicPath: '/',
+    pluginOptions: {
+      compression:{
+        brotli: {
+          filename: '[file].br[query]',
+          algorithm: 'brotliCompress',
+          include: /\.(js|css|html|svg|json)(\?.*)?$/i,
+          compressionOptions: {
+            params: {
+              [zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+            },
+          },
+          minRatio: 0.8,
+        },
+        gzip: {
+          filename: '[file].gz[query]',
+          algorithm: 'gzip',
+          include: /\.(js|css|html|svg|json)(\?.*)?$/i,
+          minRatio: 0.8,
+        }
+      }
+    }
 }


### PR DESCRIPTION
### Description

The goal is to enable **automatic asset compression** and integrate it on the build flow, to minimize total network bytes.
this PR adding **a Brotli and gzip compression plugin**, which automatically compress .js, .css, .HTML, .svg and .json files when the build triggered using both Brotli and Gzip compression.
 
The idea of preparing both .br and .gzip files is to use [Brotli](https://en.wikipedia.org/wiki/Brotli) when possible because it offers compression superior to gzip but falls back to Gzip as it is supported in all browsers.

The thing which I confused early is that the `compression-webpack-plugin` only compresses files, but it doesn't tell the HTTP server to serve the compressed files in place of the original file unless it is configured to do so.

without telling the server to do so, the compressed files will lay down with no use on the server. On the other side, configuring the HTTP server to take advantage of the text compression would have a big positive impact on the web performance.

so there are two steps
1- integrate the use of the compression plugin with our build flow. -> This PR
2- configure the Proxy/HTTP server to serve the precompressed assets.
profit!

it should be pretty easy to accomplish, caddy (which I guess is what serving our dist) can easily be set up to serve the precompressed assets, in Caddy 2.4.x it just takes:
```
file_server {
    precompressed br gzip
}
```

The above will handle an incoming request for an asset by analyzing the Accept-Encoding header provided by the client (browser) and searching for files ending in .br, and .gz, respectively (the artifacts produced from `compression-webpack-plugin`).

### Changes

- adding [vue-cli-plugin-compression](https://www.npmjs.com/package/vue-cli-plugin-compression) to dependencies.
- adding `vue-cli-plugin-compression` default configuration in easy-docs/vue.config.js

### Related Issues

threefoldtech/tfgrid-sdk-ts#164
