### PR TITLE
Fixed rootFs null error

### DIFF
--- a/src/utils/rootFs.ts
+++ b/src/utils/rootFs.ts
@@ -6,6 +6,9 @@ export default function rootFs(
   cpu_in_cores: number,
   mem_in_mb: number
 ): number {
+  cpu_in_cores = cpu_in_cores || 0;
+  mem_in_mb = mem_in_mb || 0;
+
   const cu = new Decimal(cpu_in_cores)
     .mul(mem_in_mb)
     .divToInt(8 * GB)


### PR DESCRIPTION
### Updates
- Added check if any of params of `rootFs` is null

### Related Issues
- https://github.com/threefoldtech/grid_weblets/issues/436