### PR TITLE
new naming rules

### DIFF
--- a/src/elements/DeployedList/DeployedList.wc.svelte
+++ b/src/elements/DeployedList/DeployedList.wc.svelte
@@ -77,10 +77,14 @@
   }
 
   let removing: string = null;
-  function onRemoveHandler(key: "k8s" | "machines", name: string) {
+  function onRemoveHandler(
+    key: "k8s" | "machines",
+    name: string,
+    type: string
+  ) {
     removing = name;
     window.configs.currentDeploymentStore.deploy("Deleting Deployment", name);
-    return deleteContracts(profile, key, name)
+    return deleteContracts(profile, key, name, type)
       .catch((err) => {
         console.log("Error while removing", err);
         message = err.message || err;
@@ -134,7 +138,9 @@
 
     const key = active === "k8s" ? "k8s" : "machines";
     for (const row of selectedRows) {
-      await onRemoveHandler(key, row.name);
+      // format the value of the tab to match the project name on the gridclient
+      let projectName = active[0].toUpperCase() + active.slice(1);
+      await onRemoveHandler(key, row.name, projectName);
     }
     selectedRows = [];
     _reloadTab();

--- a/src/elements/DeployedList/DeployedList.wc.svelte
+++ b/src/elements/DeployedList/DeployedList.wc.svelte
@@ -138,9 +138,7 @@
 
     const key = active === "k8s" ? "k8s" : "machines";
     for (const row of selectedRows) {
-      // format the value of the tab to match the project name on the gridclient
-      let projectName = active[0].toUpperCase() + active.slice(1);
-      await onRemoveHandler(key, row.name, projectName);
+      await onRemoveHandler(key, row.name, active);
     }
     selectedRows = [];
     _reloadTab();
@@ -284,7 +282,7 @@
 
         <!-- Caprover -->
       {:else if active === "caprover"}
-        {#await list?.loadDeployments("CapRover", "caprover")}
+        {#await list?.loadDeployments(active)}
           <Alert type="info" message="Listing CapRover..." />
         {:then rows}
           {#if rows.length}
@@ -329,7 +327,7 @@
 
         <!-- Peertube -->
       {:else if active === "peertube"}
-        {#await list?.loadDeployments("Peertube", "peertube")}
+        {#await list?.loadDeployments(active)}
           <Alert type="info" message="Listing Peertube..." />
         {:then rows}
           {#if rows.length}
@@ -377,7 +375,7 @@
 
         <!-- FunkWhale -->
       {:else if active === "funkwhale"}
-        {#await list?.loadDeployments("Funkwhale", "funk")}
+        {#await list?.loadDeployments(active)}
           <Alert type="info" message="Listing Funkwhale..." />
         {:then rows}
           {#if rows.length}
@@ -420,7 +418,7 @@
 
         <!-- Taiga -->
       {:else if active === "taiga"}
-        {#await list.loadDeployments("Taiga", "taiga")}
+        {#await list.loadDeployments(active)}
           <Alert type="info" message="Listing Taiga Instances..." />
         {:then rows}
           {#if rows.length}
@@ -480,7 +478,7 @@
 
         <!-- Mattermost -->
       {:else if active === "mattermost"}
-        {#await list?.loadDeployments("Mattermost", "mattermost")}
+        {#await list?.loadDeployments(active)}
           <Alert type="info" message="Listing Mattermost..." />
         {:then rows}
           {#if rows.length}
@@ -523,7 +521,7 @@
 
         <!-- Discourse -->
       {:else if active === "discourse"}
-        {#await list?.loadDeployments("Discourse", "discourse")}
+        {#await list?.loadDeployments(active)}
           <Alert type="info" message="Listing Discourse..." />
         {:then rows}
           {#if rows.length}
@@ -566,7 +564,7 @@
 
         <!-- Owncloud -->
       {:else if active === "owncloud"}
-        {#await list.loadDeployments("Owncloud", "owncloud")}
+        {#await list.loadDeployments(active)}
           <Alert type="info" message="Listing owncloud Instances..." />
         {:then rows}
           {#if rows.length}
@@ -612,7 +610,7 @@
 
         <!-- Presearch -->
       {:else if active === "presearch"}
-        {#await list.loadDeployments("Presearch", "presearch")}
+        {#await list.loadDeployments(active)}
           <Alert type="info" message="Listing presearch Instances..." />
         {:then rows}
           {#if rows.length}

--- a/src/elements/DeployedList/DeployedList.wc.svelte
+++ b/src/elements/DeployedList/DeployedList.wc.svelte
@@ -278,7 +278,7 @@
 
         <!-- Caprover -->
       {:else if active === "caprover"}
-        {#await list?.loadCaprover()}
+        {#await list?.loadDeployments("CapRover", "caprover")}
           <Alert type="info" message="Listing CapRover..." />
         {:then rows}
           {#if rows.length}
@@ -323,7 +323,7 @@
 
         <!-- Peertube -->
       {:else if active === "peertube"}
-        {#await list?.loadPeertube()}
+        {#await list?.loadDeployments("Peertube", "peertube")}
           <Alert type="info" message="Listing Peertube..." />
         {:then rows}
           {#if rows.length}
@@ -371,7 +371,7 @@
 
         <!-- FunkWhale -->
       {:else if active === "funkwhale"}
-        {#await list?.loadFunkwhale()}
+        {#await list?.loadDeployments("Funkwhale", "funk")}
           <Alert type="info" message="Listing Funkwhale..." />
         {:then rows}
           {#if rows.length}
@@ -414,7 +414,7 @@
 
         <!-- Taiga -->
       {:else if active === "taiga"}
-        {#await list.loadTaiga()}
+        {#await list.loadDeployments("Taiga", "taiga")}
           <Alert type="info" message="Listing Taiga Instances..." />
         {:then rows}
           {#if rows.length}
@@ -474,7 +474,7 @@
 
         <!-- Mattermost -->
       {:else if active === "mattermost"}
-        {#await list?.loadMattermost()}
+        {#await list?.loadDeployments("Mattermost", "mattermost")}
           <Alert type="info" message="Listing Mattermost..." />
         {:then rows}
           {#if rows.length}
@@ -517,7 +517,7 @@
 
         <!-- Discourse -->
       {:else if active === "discourse"}
-        {#await list?.loadDiscourse()}
+        {#await list?.loadDeployments("Discourse", "discourse")}
           <Alert type="info" message="Listing Discourse..." />
         {:then rows}
           {#if rows.length}
@@ -560,7 +560,7 @@
 
         <!-- Owncloud -->
       {:else if active === "owncloud"}
-        {#await list.loadOwncloud()}
+        {#await list.loadDeployments("Owncloud", "owncloud")}
           <Alert type="info" message="Listing owncloud Instances..." />
         {:then rows}
           {#if rows.length}
@@ -606,7 +606,7 @@
 
         <!-- Presearch -->
       {:else if active === "presearch"}
-        {#await list.loadPresearch()}
+        {#await list.loadDeployments("Presearch", "presearch")}
           <Alert type="info" message="Listing presearch Instances..." />
         {:then rows}
           {#if rows.length}

--- a/src/elements/discourse/Discourse.wc.svelte
+++ b/src/elements/discourse/Discourse.wc.svelte
@@ -81,7 +81,7 @@
 
     deployDiscourse(data, profile)
       .then((data: any) => {
-        modalData = data;
+        modalData = data.deploymentInfo;
         deploymentStore.set(0);
         success = true;
       })

--- a/src/elements/presearch/Presearch.wc.svelte
+++ b/src/elements/presearch/Presearch.wc.svelte
@@ -90,7 +90,7 @@
 
     deployPresearch(data, profile)
       .then((data: any) => {
-        modalData = data;
+        modalData = data.deploymentInfo;
         deploymentStore.set(0);
         success = true;
       })

--- a/src/elements/taiga/Taiga.wc.svelte
+++ b/src/elements/taiga/Taiga.wc.svelte
@@ -158,7 +158,7 @@
       .then((data) => {
         deploymentStore.set(0);
         success = true;
-        modalData = data.deployment;
+        modalData = data.deploymentInfo;
       })
       .catch((err: Error) => {
         failed = true;

--- a/src/stores/currentDeployment.ts
+++ b/src/stores/currentDeployment.ts
@@ -14,7 +14,8 @@ export interface IStore {
     | "Deleting Deployment"
     | "Taiga"
     | "Owncloud"
-    | "Presearch";
+    | "Presearch"
+    | "Mattermost";
   name: string;
   message: string;
 }

--- a/src/types/deployedList.ts
+++ b/src/types/deployedList.ts
@@ -93,9 +93,7 @@ export default class DeployedList {
   }
 
   public loadCaprover(): Promise<any[]> {
-    return this.loadVm().then((vms) => {
-      return vms.filter((vm) => vm.flist.toLowerCase().includes("caprover"));
-    });
+    return this.loadVm("CapRover");
   }
 
   public loadDiscourse(): Promise<any[]> {

--- a/src/types/deployedList.ts
+++ b/src/types/deployedList.ts
@@ -75,8 +75,10 @@ export default class DeployedList {
     });
   }
 
-  public loadVm(): Promise<any[]> {
+  public loadVm(projectName?: string): Promise<any[]> {
     try {
+      this.grid.projectName = projectName;
+      this.grid._connect(); // update the values of grid props
       return this.grid.machines
         .list()
         .then((names) => {
@@ -109,9 +111,7 @@ export default class DeployedList {
   }
 
   public loadPeertube(): Promise<any[]> {
-    return this.loadVm().then((vms) => {
-      return vms.filter((vm) => vm.flist.toLowerCase().includes("peertube"));
-    });
+    return this.loadVm("Peertube");
   }
 
   public loadMattermost(): Promise<any[]> {

--- a/src/types/deployedList.ts
+++ b/src/types/deployedList.ts
@@ -105,9 +105,7 @@ export default class DeployedList {
   }
 
   public loadFunkwhale(): Promise<any[]> {
-    return this.loadVm().then((vms) => {
-      return vms.filter((vm) => vm.flist.toLowerCase().includes("funk"));
-    });
+    return this.loadVm("Funkwhale");
   }
 
   public loadPeertube(): Promise<any[]> {

--- a/src/types/deployedList.ts
+++ b/src/types/deployedList.ts
@@ -77,7 +77,9 @@ export default class DeployedList {
 
   public loadVm(projectName?: string): Promise<any[]> {
     try {
-      this.grid.projectName = projectName;
+      projectName
+        ? (this.grid.projectName = projectName)
+        : (this.grid.projectName = "");
       this.grid._connect(); // update the values of grid props
       return this.grid.machines
         .list()

--- a/src/types/deployedList.ts
+++ b/src/types/deployedList.ts
@@ -99,9 +99,7 @@ export default class DeployedList {
   }
 
   public loadDiscourse(): Promise<any[]> {
-    return this.loadVm().then((vms) => {
-      return vms.filter((vm) => vm.flist.toLowerCase().includes("discourse"));
-    });
+    return this.loadVm("Discourse");
   }
 
   public loadFunkwhale(): Promise<any[]> {

--- a/src/types/deployedList.ts
+++ b/src/types/deployedList.ts
@@ -122,9 +122,7 @@ export default class DeployedList {
     return this.loadVm("Taiga");
   }
   public loadPresearch(): Promise<any[]> {
-    return this.loadVm().then((vms) => {
-      return vms.filter((vm) => vm.flist.toLowerCase().includes("presearch"));
-    });
+    return this.loadVm("Presearch");
   }
 
   public static async init(profile: IProfile): Promise<DeployedList> {

--- a/src/types/deployedList.ts
+++ b/src/types/deployedList.ts
@@ -78,9 +78,10 @@ export default class DeployedList {
   public loadVm(projectName?: string): Promise<any[]> {
     try {
       projectName
-        ? (this.grid.projectName = projectName)
-        : (this.grid.projectName = "");
+        ? (this.grid.projectName = projectName) // to load project named deployments
+        : (this.grid.projectName = ""); // to load orphan deployments
       this.grid._connect(); // update the values of grid props
+
       return this.grid.machines
         .list()
         .then((names) => {
@@ -94,35 +95,16 @@ export default class DeployedList {
     }
   }
 
-  public loadCaprover(): Promise<any[]> {
-    return this.loadVm("CapRover");
-  }
+  public async loadDeployments(projectName, flistKey) {
+    // list the deployment created without project name that includes `flistkey` "Backward compatibility"
+    let deps1 = await this.loadVm().then((vms) => {
+      return vms.filter((vm) => vm.flist.toLowerCase().includes(flistKey));
+    });
 
-  public loadDiscourse(): Promise<any[]> {
-    return this.loadVm("Discourse");
-  }
+    // list deployments create with project name
+    let deps2 = await this.loadVm(projectName);
 
-  public loadFunkwhale(): Promise<any[]> {
-    return this.loadVm("Funkwhale");
-  }
-
-  public loadPeertube(): Promise<any[]> {
-    return this.loadVm("Peertube");
-  }
-
-  public loadMattermost(): Promise<any[]> {
-    return this.loadVm("Mattermost");
-  }
-
-  public loadOwncloud(): Promise<any[]> {
-    return this.loadVm("Owncloud");
-  }
-
-  public loadTaiga(): Promise<any[]> {
-    return this.loadVm("Taiga");
-  }
-  public loadPresearch(): Promise<any[]> {
-    return this.loadVm("Presearch");
+    return [...deps1, ...deps2];
   }
 
   public static async init(profile: IProfile): Promise<DeployedList> {

--- a/src/types/deployedList.ts
+++ b/src/types/deployedList.ts
@@ -95,14 +95,14 @@ export default class DeployedList {
     }
   }
 
-  public async loadDeployments(projectName, flistKey) {
+  public async loadDeployments(type) {
     // list the deployment created without project name that includes `flistkey` "Backward compatibility"
     let deps1 = await this.loadVm().then((vms) => {
-      return vms.filter((vm) => vm.flist.toLowerCase().includes(flistKey));
+      return vms.filter((vm) => vm.flist.toLowerCase().includes(type));
     });
 
     // list deployments create with project name
-    let deps2 = await this.loadVm(projectName);
+    let deps2 = await this.loadVm(type);
 
     return [...deps1, ...deps2];
   }

--- a/src/types/deployedList.ts
+++ b/src/types/deployedList.ts
@@ -121,9 +121,7 @@ export default class DeployedList {
   }
 
   public loadTaiga(): Promise<any[]> {
-    return this.loadVm().then((vms) => {
-      return vms.filter((vm) => vm.flist.toLowerCase().includes("taiga"));
-    });
+    return this.loadVm("Taiga");
   }
   public loadPresearch(): Promise<any[]> {
     return this.loadVm().then((vms) => {

--- a/src/types/deployedList.ts
+++ b/src/types/deployedList.ts
@@ -115,9 +115,7 @@ export default class DeployedList {
   }
 
   public loadOwncloud(): Promise<any[]> {
-    return this.loadVm().then((vms) => {
-      return vms.filter((vm) => vm.flist.toLowerCase().includes("owncloud"));
-    });
+    return this.loadVm("Owncloud");
   }
 
   public loadTaiga(): Promise<any[]> {

--- a/src/types/deployedList.ts
+++ b/src/types/deployedList.ts
@@ -113,9 +113,7 @@ export default class DeployedList {
   }
 
   public loadMattermost(): Promise<any[]> {
-    return this.loadVm().then((vms) => {
-      return vms.filter((vm) => vm.flist.toLowerCase().includes("mattermost"));
-    });
+    return this.loadVm("Mattermost");
   }
 
   public loadOwncloud(): Promise<any[]> {

--- a/src/types/discourse.ts
+++ b/src/types/discourse.ts
@@ -79,6 +79,7 @@ export default class Discourse {
     public publicIp = false,
     public planetary = true,
     public disks = [new Disk(undefined, undefined, diskSize, undefined)],
+    public domain = "",
 
     public developerEmail = "",
 

--- a/src/types/funkwhale.ts
+++ b/src/types/funkwhale.ts
@@ -6,4 +6,5 @@ export default class Funkwhale extends VM {
   public adminEmail = "";
   public adminUsername = "admin";
   public adminPassword = generatePassword((length = Math.floor(Math.random() * 5) + 10)); // prettier-ignore
+  public domain = "";
 }

--- a/src/types/owncloud.ts
+++ b/src/types/owncloud.ts
@@ -5,46 +5,54 @@ import { validateEmail, validateOptionalEmail } from "../utils/validateName";
 import validateName from "../utils/validateName";
 import validateDomainName from "../utils/validateDomainName";
 export default class Owncloud extends VM {
-    /* Superuser settings */
-    public adminEmail = "";
-    public adminUsername = "admin";
-    public adminPassword = generatePassword((length = Math.floor(Math.random() * 5) + 10)); // prettier-ignore
+  /* Superuser settings */
+  public adminEmail = "";
+  public adminUsername = "admin";
+  public adminPassword = generatePassword((length = Math.floor(Math.random() * 5) + 10)); // prettier-ignore
 
-    /* Mail server settings */
-    public smtpFromEmail = "";
-    public smtpHost = "";
-    public smtpPort = "";
-    public smtpHostUser = "";
-    public smtpHostPassword = "";
-    public smtpUseTLS = false;
-    public smtpUseSSL = false;
-    
-    public cpu = 8;
-    public memory = 8192;
-    public diskSize = 100;
+  /* Mail server settings */
+  public smtpFromEmail = "";
+  public smtpHost = "";
+  public smtpPort = "";
+  public smtpHostUser = "";
+  public smtpHostPassword = "";
+  public smtpUseTLS = false;
+  public smtpUseSSL = false;
 
-    public get valid(): boolean {
-        const { name, flist, cpu, memory, diskSize, entrypoint, nodeId } = this;
-        const { network, envs, disks } = this;
-        const { adminUsername, adminPassword } = this;
-        const { smtpFromEmail, smtpHost, smtpPort, smtpHostUser, smtpHostPassword } = this;
+  public cpu = 8;
+  public memory = 8192;
+  public diskSize = 100;
 
-        return (
-            name !== "" &&
-            flist !== "" &&
-            entrypoint !== "" &&
-            isValidInteger(cpu) &&
-            isValidInteger(memory) &&
-            isValidInteger(nodeId) &&
-            network.valid &&
-            envs.reduce((res, env) => res && env.valid, true) &&
-            disks.reduce((res, disk) => res && disk.valid, true) &&
-            !validateName(adminUsername) &&
-            adminPassword !== "" &&
-            !validateOptionalEmail(smtpFromEmail) &&
-            !validateOptionalEmail(smtpHostUser) &&
-            (!validateDomainName(smtpHost) || smtpHost === "") &&
-            (isValidInteger(smtpPort) || smtpPort === "")
-        );
-    }
+  public domain = "";
+
+  public get valid(): boolean {
+    const { name, flist, cpu, memory, diskSize, entrypoint, nodeId } = this;
+    const { network, envs, disks } = this;
+    const { adminUsername, adminPassword } = this;
+    const {
+      smtpFromEmail,
+      smtpHost,
+      smtpPort,
+      smtpHostUser,
+      smtpHostPassword,
+    } = this;
+
+    return (
+      name !== "" &&
+      flist !== "" &&
+      entrypoint !== "" &&
+      isValidInteger(cpu) &&
+      isValidInteger(memory) &&
+      isValidInteger(nodeId) &&
+      network.valid &&
+      envs.reduce((res, env) => res && env.valid, true) &&
+      disks.reduce((res, disk) => res && disk.valid, true) &&
+      !validateName(adminUsername) &&
+      adminPassword !== "" &&
+      !validateOptionalEmail(smtpFromEmail) &&
+      !validateOptionalEmail(smtpHostUser) &&
+      (!validateDomainName(smtpHost) || smtpHost === "") &&
+      (isValidInteger(smtpPort) || smtpPort === "")
+    );
+  }
 }

--- a/src/types/peertube.ts
+++ b/src/types/peertube.ts
@@ -10,4 +10,5 @@ export default class Peertube extends VM {
   public cpu = 2;
   public memory = 1024 * 2;
   public disks = [new Disk(undefined, undefined, 20, undefined)];
+  public domain = "";
 }

--- a/src/types/taiga.ts
+++ b/src/types/taiga.ts
@@ -16,6 +16,7 @@ export default class Taiga extends VM {
   public smtpPort = "";
   public smtpHostUser = "";
   public smtpHostPassword = "";
+  public domain = "";
 
   public smtpUseTLS = false;
   public smtpUseSSL = false;
@@ -23,7 +24,13 @@ export default class Taiga extends VM {
     const { name, flist, cpu, memory, entrypoint, nodeId } = this;
     const { network, envs, disks } = this;
     const { adminEmail, adminUsername, adminPassword } = this;
-    const { smtpFromEmail, smtpHost, smtpPort, smtpHostUser, smtpHostPassword } = this;
+    const {
+      smtpFromEmail,
+      smtpHost,
+      smtpPort,
+      smtpHostUser,
+      smtpHostPassword,
+    } = this;
 
     return (
       name !== "" &&

--- a/src/utils/checkVM.ts
+++ b/src/utils/checkVM.ts
@@ -1,0 +1,17 @@
+export default async function checkVMExist(grid, type, name) {
+  // check if the vm exists in default namespace
+  const oldVM = await grid.machines.getObj(name);
+  if (oldVM.length != 0) {
+    const flist = oldVM[0]["flist"] as string;
+    if (flist.includes(type)) {
+      throw Error(
+        `Another ${type} deployment with the same name ${name} already exists`
+      );
+    }
+  }
+
+  // For invalidating the cashed keys in the KV store, getObj check if the key has no deployments. it is deleted.
+  grid.projectName = type;
+  grid._connect();
+  await grid.machines.getObj(name);
+}

--- a/src/utils/deleteContracts.ts
+++ b/src/utils/deleteContracts.ts
@@ -7,10 +7,11 @@ interface IConfig {
   networkEnv: string;
 }
 
-export default function deleteContracts(
+export default async function deleteContracts(
   configs: IConfig,
   key: "k8s" | "machines",
-  name: string
+  name: string,
+  type: string
 ) {
   const { mnemonics, networkEnv, storeSecret } = configs;
   const http = new HTTPMessageBusClient(0, "", "", "");
@@ -19,10 +20,21 @@ export default function deleteContracts(
     mnemonics,
     storeSecret,
     http,
-    undefined,
+    type,
     "tfkvstore" as any
   );
 
+  // remove named vms
+  console.log({ grid });
+  await grid.connect().then(() => {
+    return grid[key].delete({ name });
+  });
+
+  grid.projectName = "";
+  await grid._connect();
+
+  // remove orphan vms
+  console.log({ grid });
   return grid.connect().then(() => {
     return grid[key].delete({ name });
   });

--- a/src/utils/deleteContracts.ts
+++ b/src/utils/deleteContracts.ts
@@ -26,9 +26,13 @@ export default async function deleteContracts(
 
   // remove named vms
   console.log({ grid });
-  await grid.connect().then(() => {
+  const obj = await grid.connect().then(() => {
     return grid[key].delete({ name });
   });
+
+  if (obj["deleted"].length) {
+    return obj;
+  }
 
   grid.projectName = "";
   await grid._connect();

--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -10,14 +10,19 @@ export default function deploy<T>(
   deployer: (grid: GridClient) => Promise<T>
 ) {
   window.configs.currentDeploymentStore.deploy(type, name);
-  return getGrid(profile, (grid) => {
-    return deployer(grid)
-      .then((res) => {
-        window.configs.balanceStore.updateBalance();
-        return res;
-      })
-      .finally(() => {
-        window.configs.currentDeploymentStore.clear();
-      });
-  });
+  return getGrid(
+    profile,
+    (grid) => {
+      return deployer(grid)
+        .then((res) => {
+          window.configs.balanceStore.updateBalance();
+          return res;
+        })
+        .finally(() => {
+          window.configs.currentDeploymentStore.clear();
+        });
+    },
+    undefined,
+    type
+  );
 }

--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -3,26 +3,21 @@ import type { IStore } from "../stores/currentDeployment";
 import type { IProfile } from "../types/Profile";
 import getGrid from "./getGrid";
 
-export default function deploy<T>(
+export default async function deploy<T>(
   profile: IProfile,
   type: IStore["type"],
   name: string,
   deployer: (grid: GridClient) => Promise<T>
 ) {
   window.configs.currentDeploymentStore.deploy(type, name);
-  return getGrid(
-    profile,
-    (grid) => {
-      return deployer(grid)
-        .then((res) => {
-          window.configs.balanceStore.updateBalance();
-          return res;
-        })
-        .finally(() => {
-          window.configs.currentDeploymentStore.clear();
-        });
-    },
-    undefined,
-    type
-  );
+  return getGrid(profile, (grid) => {
+    return deployer(grid)
+      .then((res) => {
+        window.configs.balanceStore.updateBalance();
+        return res;
+      })
+      .finally(() => {
+        window.configs.currentDeploymentStore.clear();
+      });
+  });
 }

--- a/src/utils/deployCaprover.ts
+++ b/src/utils/deployCaprover.ts
@@ -1,6 +1,7 @@
 import type Caprover from "../types/caprover";
 import { Network } from "../types/kubernetes";
 import type { IProfile } from "../types/Profile";
+import checkVMExist from "./checkVM";
 import createNetwork from "./createNetwork";
 import deploy from "./deploy";
 import rootFs from "./rootFs";
@@ -51,7 +52,7 @@ export default async function deployCaprover(
   machines.description = "caprover leader machine/node";
 
   return deploy(profile, "CapRover", name, async (grid) => {
-    await grid.machines.getObj(name);
+    await checkVMExist(grid, "caprover", name);
     return grid.machines
       .deploy(machines)
       .then(() => grid.machines.getObj(name))

--- a/src/utils/deployCaprover.ts
+++ b/src/utils/deployCaprover.ts
@@ -3,10 +3,9 @@ import { Network } from "../types/kubernetes";
 import type { IProfile } from "../types/Profile";
 import createNetwork from "./createNetwork";
 import deploy from "./deploy";
-import getGrid from "./getGrid";
 import rootFs from "./rootFs";
-// const { HTTPMessageBusClient } = window.configs?.client ?? {};
-const { MachinesModel, DiskModel /* , GridClient */, MachineModel } =
+
+const { MachinesModel, DiskModel, MachineModel } =
   window.configs?.grid3_client ?? {};
 
 const CAPROVER_FLIST =
@@ -18,7 +17,6 @@ export default async function deployCaprover(
 ) {
   const { name, memory, nodeId, publicKey, cpu, domain, diskSize, password } = data; // prettier-ignore
 
-  // const http = new HTTPMessageBusClient(0, "");
   const network = createNetwork(new Network(`NW${name}`, "10.200.0.0/16")); // prettier-ignore
 
   /* Docker disk */
@@ -52,7 +50,8 @@ export default async function deployCaprover(
   machines.network = network;
   machines.description = "caprover leader machine/node";
 
-  return deploy(profile, "CapRover", name, (grid) => {
+  return deploy(profile, "CapRover", name, async (grid) => {
+    await grid.machines.getObj(name);
     return grid.machines
       .deploy(machines)
       .then(() => grid.machines.getObj(name))

--- a/src/utils/deployDiscourse.ts
+++ b/src/utils/deployDiscourse.ts
@@ -20,11 +20,10 @@ export default async function deployDiscourse(
   profile: IProfile
 ) {
   let domainName = await getUniqueDomainName(
-    "client",
-    "dc",
-    data.name,
     profile,
-    "Discourse"
+    data.name,
+    "Discourse",
+    "dc"
   );
 
   let [publicNodeId, nodeDomain] = await selectGatewayNode();

--- a/src/utils/deployDiscourse.ts
+++ b/src/utils/deployDiscourse.ts
@@ -6,6 +6,7 @@ import createNetwork from "./createNetwork";
 import deploy from "./deploy";
 import rootFs from "./rootFs";
 import destroy from "./destroy";
+import checkVMExist from "./checkVM";
 
 const {
   generateString,
@@ -108,8 +109,7 @@ async function depoloyDiscourseVM(data: Discourse, profile: IProfile) {
   machines.description = "discourse machine/node";
 
   return deploy(profile, "Discourse", name, async (grid) => {
-    // For invalidating the cashed keys in the KV store, getObj check if the key has no deployments. it is deleted.
-    await grid.machines.getObj(name);
+    await checkVMExist(grid, "discourse", name);
     return grid.machines
       .deploy(machines)
       .then(() => grid.machines.getObj(name))

--- a/src/utils/deployDiscourse.ts
+++ b/src/utils/deployDiscourse.ts
@@ -5,80 +5,51 @@ import type { IProfile } from "../types/Profile";
 import createNetwork from "./createNetwork";
 import deploy from "./deploy";
 import rootFs from "./rootFs";
+import destroy from "./destroy";
 
 const {
   generateString,
   MachinesModel,
   DiskModel,
-  GridClient,
   MachineModel,
   GatewayNameModel,
 } = window.configs?.grid3_client ?? {};
-
-const { HTTPMessageBusClient } = window.configs?.client ?? {};
-
-const DISCOURSE_FLIST =
-  "https://hub.grid.tf/rafybenjamin.3bot/threefolddev-discourse-v4.0.flist";
 
 export default async function deployDiscourse(
   data: Discourse,
   profile: IProfile
 ) {
-  const name = data.name;
-  const { mnemonics, storeSecret, networkEnv, sshKey } = profile;
-
-  const http = new HTTPMessageBusClient(0, "", "", "");
-  const client = new GridClient(
-    networkEnv as any,
-    mnemonics,
-    storeSecret,
-    http,
-    undefined,
-    "tfkvstore" as any
+  let domainName = await getUniqueDomainName(
+    "client",
+    "dc",
+    data.name,
+    profile,
+    "Discourse"
   );
 
-  await client.connect();
-
-  let randomSuffix = generateString(10).toLowerCase();
-
-  const network = createNetwork(new Network(`nw${randomSuffix}`, "10.200.0.0/16")); // prettier-ignore
-
-  let domainName = await getUniqueDomainName(client, "dc", name);
-
   let [publicNodeId, nodeDomain] = await selectGatewayNode();
-  const domain = `${domainName}.${nodeDomain}`;
+  data.domain = `${domainName}.${nodeDomain}`;
 
-  await depoloyDiscourseVM(data, profile, domain, network, randomSuffix);
+  const deploymentInfo = await depoloyDiscourseVM(data, profile);
 
-  const discourseInfo = await getDiscourseInfo(client, name);
-  const planetaryIP = discourseInfo[0]["planetary"] as string;
-  const publicIP = discourseInfo[0]["publicIP"]
-    ? discourseInfo[0]["publicIP"]["ip"].split("/")[0]
-    : "";
+  const planetaryIP = deploymentInfo["planetary"] as string;
+
+  // const publicIP = deploymentInfo[0]["publicIP"]
+  //   ? deploymentInfo[0]["publicIP"]["ip"].split("/")[0]
+  //   : "";
 
   try {
-    await deployPrefixGateway(
-      profile,
-      client,
-      domainName,
-      planetaryIP,
-      publicNodeId,
-      publicIP
-    );
+    await deployPrefixGateway(profile, domainName, planetaryIP, publicNodeId);
   } catch (error) {
     // rollback peertube deployment if gateway deployment failed
-    await client.machines.delete({ name: name });
+    await destroy(profile, "Discourse", data.name);
     throw error;
   }
+
+  return { deploymentInfo };
 }
 
-async function depoloyDiscourseVM(
-  data: Discourse,
-  profile: IProfile,
-  domain: string,
-  network: any,
-  randomeSuffix: string
-) {
+async function depoloyDiscourseVM(data: Discourse, profile: IProfile) {
   const {
     name,
     cpu,
@@ -91,23 +62,29 @@ async function depoloyDiscourseVM(
     flaskSecretKey,
     publicIp,
     planetary,
+    domain,
   } = data;
+
+  let randomSuffix = generateString(10).toLowerCase();
+
+  const network = createNetwork(new Network(`nw${randomSuffix}`));
 
   /* Docker disk */
   const disk = new DiskModel();
-  disk.name = `disk${randomeSuffix}`;
+  disk.name = `disk${randomSuffix}`;
   disk.size = diskSize;
   disk.mountpoint = "/var/lib/docker";
 
   const machine = new MachineModel();
-  machine.name = `vm${randomeSuffix}`;
+  machine.name = `vm${randomSuffix}`;
   machine.cpu = cpu;
   machine.memory = memory;
   machine.disks = [disk];
   machine.node_id = nodeId;
   machine.public_ip = publicIp;
   machine.planetary = planetary;
-  machine.flist = DISCOURSE_FLIST;
+  machine.flist =
+    "https://hub.grid.tf/rafybenjamin.3bot/threefolddev-discourse-v4.0.flist";
   machine.qsfs_disks = [];
   machine.rootfs_size = rootFs(cpu, memory);
   machine.entrypoint = "/.start_discourse.sh";
@@ -131,23 +108,21 @@ async function depoloyDiscourseVM(
   machines.network = network;
   machines.description = "discourse machine/node";
 
-  return deploy(profile, "Discourse", name, (grid) => {
-    return grid.machines.deploy(machines);
+  return deploy(profile, "Discourse", name, async (grid) => {
+    // For invalidating the cashed keys in the KV store, getObj check if the key has no deployments. it is deleted.
+    await grid.machines.getObj(name);
+    return grid.machines
+      .deploy(machines)
+      .then(() => grid.machines.getObj(name))
+      .then(([vm]) => vm);
   });
-}
-
-async function getDiscourseInfo(client: any, name: string) {
-  const info = await client.machines.getObj(name);
-  return info;
 }
 
 async function deployPrefixGateway(
   profile: IProfile,
-  client: any,
   domainName: string,
   backend: string,
-  publicNodeId: number,
-  publicIP: string
+  publicNodeId: number
 ) {
   // define specs
   const gw = new GatewayNameModel();
@@ -156,7 +131,12 @@ async function deployPrefixGateway(
   gw.tls_passthrough = false;
   gw.backends = [`http://[${backend}]:80`];
 
-  return deploy(profile, "GatewayName", domainName, (grid) => {
-    return grid.gateway.deploy_name(gw);
+  return deploy(profile, "GatewayName", domainName, async (grid) => {
+    // For invalidating the cashed keys in the KV store, getObj check if the key has no deployments. it is deleted.
+    await grid.gateway.getObj(domainName);
+    return grid.gateway
+      .deploy_name(gw)
+      .then(() => grid.gateway.getObj(domainName))
+      .then(([gw]) => gw);
   });
 }

--- a/src/utils/deployFunkwhale.ts
+++ b/src/utils/deployFunkwhale.ts
@@ -1,18 +1,17 @@
 import type { default as Funkwhale } from "../types/funkwhale";
 import type { IProfile } from "../types/Profile";
-import deploy from "./deploy";
-
-import { selectGatewayNode, getUniqueDomainName } from "./gatewayHelpers";
-import rootFs from "./rootFs";
-import createNetwork from "./createNetwork";
 import { Network } from "../types/kubernetes";
 
-const { HTTPMessageBusClient } = window.configs?.client ?? {};
+import { selectGatewayNode, getUniqueDomainName } from "./gatewayHelpers";
+import createNetwork from "./createNetwork";
+import deploy from "./deploy";
+import rootFs from "./rootFs";
+import destroy from "./destroy";
+
 const {
   DiskModel,
   MachineModel,
   MachinesModel,
-  GridClient,
   GatewayNameModel,
   generateString,
 } = window.configs?.grid3_client ?? {};
@@ -21,105 +20,70 @@ export default async function deployFunkwhale(
   data: Funkwhale,
   profile: IProfile
 ) {
-  const {
-    envs,
-    disks: [{ size }],
-    adminUsername,
-    adminEmail,
-    adminPassword,
-    ...base
-  } = data;
-  let { name, flist, cpu, memory, entrypoint, network: nw } = base;
-  const { publicIp, planetary, nodeId } = base;
-  const { mnemonics, storeSecret, networkEnv } = profile;
-
-  const http = new HTTPMessageBusClient(0, "", "", "");
-  const client = new GridClient(
-    networkEnv as any,
-    mnemonics,
-    storeSecret,
-    http,
-    undefined,
-    "tfkvstore" as any
-  );
-
-  await client.connect();
-
-  // sub deployments model (vm, disk, net): <type><random_suffix>
-  let randomSuffix = generateString(10).toLowerCase();
-
   // gateway model: <solution-type><twin-id><solution_name>
-  let domainName = await getUniqueDomainName(client, "fw", name);
+  let domainName = await getUniqueDomainName(
+    "grid",
+    "fw",
+    data.name,
+    profile,
+    "Funkwhale"
+  );
 
   // Dynamically select node to deploy the gateway
   let [publicNodeId, nodeDomain] = await selectGatewayNode();
-  const domain = `${domainName}.${nodeDomain}`;
+  data.domain = `${domainName}.${nodeDomain}`;
 
-  // define network
-  const network = createNetwork(new Network(`net${randomSuffix}`, "10.1.0.0/16")); // prettier-ignore
+  const deploymentInfo = await deployFunkwhaleVM(profile, data);
 
-  const deploymentInfo = await deployFunkwhaleVM(
-    profile,
-    client,
-    name,
-    network,
-    nodeId,
-    domain,
-    randomSuffix,
-    adminUsername,
-    adminEmail,
-    adminPassword,
-    size,
-    cpu,
-    memory
-  );
-
-  const info = await getFunkwhaleInfo(client, name);
-  const planetaryIP = info[0]["planetary"];
+  const planetaryIP = deploymentInfo["planetary"] as string;
 
   try {
     // deploy the gateway
-    await deployPrefixGateway(
-      profile,
-      client,
-      domainName,
-      planetaryIP,
-      publicNodeId
-    );
+    await deployPrefixGateway(profile, domainName, planetaryIP, publicNodeId);
   } catch (error) {
     // rollback the FunkwhaleVM if the gateway fails to deploy
-    await client.machines.delete({ name: name });
+    await destroy(profile, "Funkwhale", data.name);
     throw error;
   }
 
   return { deploymentInfo };
 }
 
-async function deployFunkwhaleVM(
-  profile: IProfile,
-  client: any,
-  name: string,
-  network: any,
-  nodeId: number,
-  domain: string,
-  randomSuffix: string,
-  adminUsername: string,
-  adminEmail: string,
-  adminPassword: string,
-  size: number,
-  cpu: number,
-  memory: number
-) {
+async function deployFunkwhaleVM(profile: IProfile, data: Funkwhale) {
+  const {
+    name,
+    cpu,
+    memory,
+    disks: [{ size }],
+    publicIp,
+    nodeId,
+    adminEmail,
+    adminUsername,
+    adminPassword,
+    envs,
+    domain,
+  } = data;
+
+  // sub deployments model (vm, disk, net): <type><random_suffix>
+  let randomSuffix = generateString(10).toLowerCase();
+
+  // Network Specs
+  const net = new Network();
+  net.name = `net${randomSuffix}`;
+  const network = createNetwork(net);
+
+  // Disk Specs
   const disk = new DiskModel();
   disk.name = `disk${randomSuffix}`;
   disk.size = size;
   disk.mountpoint = "/data";
 
+  // VM Specs
   const vm = new MachineModel();
   vm.name = `vm${randomSuffix}`;
   vm.node_id = nodeId;
   vm.disks = [disk];
-  vm.public_ip = false;
+  vm.public_ip = publicIp;
   vm.planetary = true;
   vm.cpu = cpu;
   vm.memory = memory;
@@ -134,24 +98,17 @@ async function deployFunkwhaleVM(
     DJANGO_SUPERUSER_PASSWORD: adminPassword,
   };
 
+  // VMS Specs
   const vms = new MachinesModel();
   vms.name = name;
   vms.network = network;
   vms.machines = [vm];
 
-  return deploy(profile, "Funkwhale", name, (grid) => {
+  return deploy(profile, "Funkwhale", name, async (grid) => {
+    // For invalidating the cashed keys in the KV store, getObj check if the key has no deployments. it is deleted.
+    await grid.machines.getObj(name);
     return grid.machines
       .deploy(vms)
-      .then(async () => {
-        for (const gw of await grid.gateway._list()) {
-          console.log(gw);
-          try {
-            await grid.gateway.getObj(gw);
-          } catch (e) {
-            console.log(e);
-          }
-        }
-      })
       .then(() => grid.machines.getObj(name))
       .then(([vm]) => vm);
   });
@@ -159,31 +116,23 @@ async function deployFunkwhaleVM(
 
 async function deployPrefixGateway(
   profile: IProfile,
-  client: any,
   domainName: string,
   backend: string,
   publicNodeId: number
 ) {
+  // Gateway Specs
   const gw = new GatewayNameModel();
   gw.name = domainName;
   gw.node_id = publicNodeId;
   gw.tls_passthrough = false;
   gw.backends = [`http://[${backend}]:80/`];
 
-  return deploy(profile, "GatewayName", domainName, (grid) => {
+  return deploy(profile, "GatewayName", domainName, async (grid) => {
+    // For invalidating the cashed keys in the KV store, getObj check if the key has no deployments. it is deleted.
+    await grid.gateway.getObj(domainName);
     return grid.gateway
       .deploy_name(gw)
       .then(() => grid.gateway.getObj(domainName))
       .then(([gw]) => gw);
   });
-}
-
-async function getFunkwhaleInfo(client: any, name: string) {
-  const info = await client.machines.getObj(name);
-  return info;
-}
-
-async function getGatewayInfo(client: any, name: string) {
-  const info = await client.gateway.getObj(name);
-  return info;
 }

--- a/src/utils/deployFunkwhale.ts
+++ b/src/utils/deployFunkwhale.ts
@@ -7,6 +7,7 @@ import createNetwork from "./createNetwork";
 import deploy from "./deploy";
 import rootFs from "./rootFs";
 import destroy from "./destroy";
+import checkVMExist from "./checkVM";
 
 const {
   DiskModel,
@@ -104,8 +105,7 @@ async function deployFunkwhaleVM(profile: IProfile, data: Funkwhale) {
   vms.machines = [vm];
 
   return deploy(profile, "Funkwhale", name, async (grid) => {
-    // For invalidating the cashed keys in the KV store, getObj check if the key has no deployments. it is deleted.
-    await grid.machines.getObj(name);
+    await checkVMExist(grid, "funkwhale", name);
     return grid.machines
       .deploy(vms)
       .then(() => grid.machines.getObj(name))

--- a/src/utils/deployFunkwhale.ts
+++ b/src/utils/deployFunkwhale.ts
@@ -22,11 +22,10 @@ export default async function deployFunkwhale(
 ) {
   // gateway model: <solution-type><twin-id><solution_name>
   let domainName = await getUniqueDomainName(
-    "grid",
-    "fw",
-    data.name,
     profile,
-    "Funkwhale"
+    data.name,
+    "Funkwhale",
+    "fw"
   );
 
   // Dynamically select node to deploy the gateway

--- a/src/utils/deployMattermost.ts
+++ b/src/utils/deployMattermost.ts
@@ -5,9 +5,9 @@ import { Network } from "../types/kubernetes";
 import { getUniqueDomainName, selectGatewayNode } from "./gatewayHelpers";
 import createNetwork from "./createNetwork";
 import deploy from "./deploy";
-// import getGrid from "./getGrid";
 import rootFs from "./rootFs";
 import destroy from "./destroy";
+import checkVMExist from "./checkVM";
 
 const {
   MachineModel,
@@ -33,7 +33,7 @@ export default async function deployMattermost(
   mattermost.domain = `${domainName}.${nodeDomain}`;
 
   const matterMostVm = await _deployMatterMost(profile, mattermost);
-  const ip = matterMostVm.planetary as string;
+  const ip = matterMostVm["planetary"] as string;
 
   try {
     await _deployGateway(profile, domainName, ip, publicNodeId);
@@ -94,7 +94,8 @@ function _deployMatterMost(profile: IProfile, mattermost: Mattermost) {
   vms.machines = [vm];
 
   return deploy(profile, "Mattermost", name, async (grid) => {
-    await grid.machines.getObj(name);
+    await checkVMExist(grid, "mattermost", name);
+
     return grid.machines
       .deploy(vms)
       .then(() => grid.machines.getObj(name))

--- a/src/utils/deployMattermost.ts
+++ b/src/utils/deployMattermost.ts
@@ -23,11 +23,10 @@ export default async function deployMattermost(
 ) {
   // gateway model: <solution-type><twin-id><solution_name>
   let domainName = await getUniqueDomainName(
-    "grid",
-    "mm",
-    mattermost.name,
     profile,
-    "Mattermost"
+    mattermost.name,
+    "Mattermost",
+    "mm"
   );
 
   let [publicNodeId, nodeDomain] = await selectGatewayNode();

--- a/src/utils/deployOwncloud.ts
+++ b/src/utils/deployOwncloud.ts
@@ -1,5 +1,6 @@
 import type { default as Owncloud } from "../types/owncloud";
 import type { IProfile } from "../types/Profile";
+import checkVMExist from "./checkVM";
 import deploy from "./deploy";
 import destroy from "./destroy";
 
@@ -132,7 +133,8 @@ async function deployOwncloudVM(profile: IProfile, data: Owncloud) {
 
   // deploy
   return deploy(profile, "Owncloud", name, async (grid) => {
-    await grid.machines.getObj(name);
+    await checkVMExist(grid, "owncloud", name);
+
     return grid.machines
       .deploy(vms)
       .then(() => grid.machines.getObj(name))

--- a/src/utils/deployOwncloud.ts
+++ b/src/utils/deployOwncloud.ts
@@ -21,11 +21,10 @@ export default async function deployOwncloud(
 ) {
   // gateway model: <solution-type><twin-id><solution_name>
   let domainName = await getUniqueDomainName(
-    "client",
-    "oc",
-    data.name,
     profile,
-    "Owncloud"
+    data.name,
+    "Owncloud",
+    "oc"
   );
 
   // Dynamically select node to deploy the gateway

--- a/src/utils/deployPeertube.ts
+++ b/src/utils/deployPeertube.ts
@@ -7,6 +7,7 @@ import createNetwork from "./createNetwork";
 import deploy from "./deploy";
 import rootFs from "./rootFs";
 import destroy from "./destroy";
+import checkVMExist from "./checkVM";
 
 const {
   DiskModel,
@@ -109,8 +110,7 @@ async function deployPeertubeVM(profile: IProfile, data: Peertube) {
 
   // deploy
   return deploy(profile, "Peertube", name, async (grid) => {
-    // For invalidating the cashed keys in the KV store, getObj check if the key has no deployments. it is deleted.
-    await grid.machines.getObj(name);
+    await checkVMExist(grid, "peertube", name);
     return grid.machines
       .deploy(vms)
       .then(() => grid.machines.getObj(name))

--- a/src/utils/deployPeertube.ts
+++ b/src/utils/deployPeertube.ts
@@ -22,11 +22,10 @@ export default async function deployPeertube(
 ) {
   // gateway model: <solution-type><twin-id><solution_name>
   let domainName = await getUniqueDomainName(
-    "grid",
-    "pt",
-    data.name,
     profile,
-    "Peertube"
+    data.name,
+    "Peertube",
+    "pt"
   );
 
   // Dynamically select node to deploy the gateway

--- a/src/utils/deployPeertube.ts
+++ b/src/utils/deployPeertube.ts
@@ -1,15 +1,14 @@
 import type { default as Peertube } from "../types/peertube";
 import type { IProfile } from "../types/Profile";
-import deploy from "./deploy";
-
-import { selectGatewayNode, getUniqueDomainName } from "./gatewayHelpers";
-import rootFs from "./rootFs";
-import createNetwork from "./createNetwork";
 import { Network } from "../types/kubernetes";
 
-const { HTTPMessageBusClient } = window.configs?.client ?? {};
+import { selectGatewayNode, getUniqueDomainName } from "./gatewayHelpers";
+import createNetwork from "./createNetwork";
+import deploy from "./deploy";
+import rootFs from "./rootFs";
+import destroy from "./destroy";
+
 const {
-  GridClient,
   DiskModel,
   MachineModel,
   MachinesModel,
@@ -21,105 +20,64 @@ export default async function deployPeertube(
   data: Peertube,
   profile: IProfile
 ) {
-  const {
-    envs,
-    disks: [{ size }],
-    adminEmail,
-    adminPassword,
-    ...base
-  } = data;
-  let { name, flist, cpu, memory, entrypoint, network: nw } = base;
-  const { publicIp, planetary, nodeId } = base;
-  const { mnemonics, storeSecret, networkEnv, sshKey } = profile;
-
-  const http = new HTTPMessageBusClient(0, "", "", "");
-  const client = new GridClient(
-    networkEnv as any,
-    mnemonics,
-    storeSecret,
-    http,
-    undefined,
-    "tfkvstore" as any
+  let domainName = await getUniqueDomainName(
+    "grid",
+    "pt",
+    data.name,
+    profile,
+    "Peertube"
   );
-
-  await client.connect();
-
-  // sub deployments model (vm, disk, net): <type><random_suffix>
-  let randomSuffix = generateString(10).toLowerCase();
-
-  // gateway model: <solution-type><twin-id><solution_name>
-  let domainName = await getUniqueDomainName(client, "pt", name);
 
   // Dynamically select node to deploy the gateway
   let [publicNodeId, nodeDomain] = await selectGatewayNode();
-  const domain = `${domainName}.${nodeDomain}`;
-
-  // define a network
-  const network = createNetwork(new Network(`net${randomSuffix}`, "10.1.0.0/16")); // prettier-ignore
+  data.domain = `${domainName}.${nodeDomain}`;
 
   // deploy the peertube
-  const deploymentInfo = await deployPeertubeVM(
-    profile,
-    client,
-    network,
-    nodeId,
-    name,
-    domain,
-    cpu,
-    memory,
-    size,
-    sshKey,
-    randomSuffix,
-    publicIp,
-    adminEmail,
-    adminPassword
-  );
+  const deploymentInfo = await deployPeertubeVM(profile, data);
 
-  // get the info of peertube deployment
-  const peertubeInfo = await getPeertubeInfo(client, name);
-  const planetaryIP = peertubeInfo[0]["planetary"];
+  const planetaryIP = deploymentInfo["planetary"] as string;
 
   try {
     // deploy the gateway
-    await deployPrefixGateway(
-      profile,
-      client,
-      domainName,
-      planetaryIP,
-      publicNodeId
-    );
+    await deployPrefixGateway(profile, domainName, planetaryIP, publicNodeId);
   } catch (error) {
     // rollback peertube deployment if gateway deployment failed
-    await client.machines.delete({ name: name });
+    await destroy(profile, "Peertube", data.name);
     throw error;
   }
 
   return { deploymentInfo };
 }
 
-async function deployPeertubeVM(
-  profile: IProfile,
-  client: any,
-  net: any,
-  nodeId: any,
-  name: string,
-  domain: string,
-  cpu: number,
-  memory: number,
-  diskSize: number,
-  sshKey: string,
-  randomSuffix: string,
-  publicIp: boolean,
-  email: string,
-  password: string
-) {
-  // disk
+async function deployPeertubeVM(profile: IProfile, data: Peertube) {
+  const {
+    name,
+    cpu,
+    memory,
+    disks: [{ size }],
+    publicIp,
+    nodeId,
+    adminEmail,
+    adminPassword,
+    envs,
+    domain,
+  } = data;
+
+  // sub deployments model (vm, disk, net): <type><random_suffix>
+  let randomSuffix = generateString(10).toLowerCase();
+
+  // Network Specs
+  const net = new Network();
+  net.name = `net${randomSuffix}`;
+  const network = createNetwork(net);
+
+  // Disk Specs
   const disk = new DiskModel();
   disk.name = `disk${randomSuffix}`;
-  disk.size = diskSize;
+  disk.size = size;
   disk.mountpoint = "/data";
 
-  // vm specs
+  // VM Specs
   const vm = new MachineModel();
   vm.name = `vm${randomSuffix}`;
   vm.node_id = nodeId;
@@ -133,9 +91,9 @@ async function deployPeertubeVM(
     "https://hub.grid.tf/omarabdul3ziz.3bot/threefoldtech-peertube-v3.1.flist";
   vm.entrypoint = "/usr/local/bin/entrypoint.sh";
   vm.env = {
-    SSH_KEY: sshKey,
-    PEERTUBE_ADMIN_EMAIL: email,
-    PT_INITIAL_ROOT_PASSWORD: password,
+    SSH_KEY: profile.sshKey,
+    PEERTUBE_ADMIN_EMAIL: adminEmail,
+    PT_INITIAL_ROOT_PASSWORD: adminPassword,
     PEERTUBE_WEBSERVER_HOSTNAME: domain,
     PEERTUBE_WEBSERVER_PORT: "443",
     PEERTUBE_DB_SUFFIX: "_prod",
@@ -143,36 +101,38 @@ async function deployPeertubeVM(
     PEERTUBE_DB_PASSWORD: "peertube",
   };
 
-  // vms specs
+  // VMS Specs
   const vms = new MachinesModel();
   vms.name = name;
-  vms.network = net;
+  vms.network = network;
   vms.machines = [vm];
 
   // deploy
   return deploy(profile, "Peertube", name, (grid) => {
-    return grid.machines
-      .deploy(vms)
-      .then(async () => {
-        for (const gw of await grid.gateway._list()) {
-          try {
-            await grid.gateway.getObj(gw);
-          } catch {}
-        }
-      })
-      .then(() => grid.machines.getObj(name))
-      .then(([vm]) => vm);
+    return (
+      grid.machines
+        .deploy(vms)
+        // For fixing the kvstore cached contracts
+        // .then(async () => {
+        //   for (const gw of await grid.gateway._list()) {
+        //     try {
+        //       await grid.gateway.getObj(gw);
+        //     } catch {}
+        //   }
+        // })
+        .then(() => grid.machines.getObj(name))
+        .then(([vm]) => vm)
+    );
   });
 }
 
 async function deployPrefixGateway(
   profile: IProfile,
-  client: any,
   domainName: string,
   backend: string,
   publicNodeId: number
 ) {
-  // define specs
+  // Gateway Specs
   const gw = new GatewayNameModel();
   gw.name = domainName;
   gw.node_id = publicNodeId;
@@ -185,14 +145,4 @@ async function deployPrefixGateway(
       .then(() => grid.gateway.getObj(domainName))
       .then(([gw]) => gw);
   });
-}
-
-async function getPeertubeInfo(client: any, name: string) {
-  const info = await client.machines.getObj(name);
-  return info;
-}
-
-async function getGatewayInfo(client: any, name: string) {
-  const info = await client.gateway.getObj(name);
-  return info;
 }

--- a/src/utils/deployPeertube.ts
+++ b/src/utils/deployPeertube.ts
@@ -134,7 +134,7 @@ async function deployPrefixGateway(
 
   return deploy(profile, "GatewayName", domainName, async (grid) => {
     // For invalidating the cashed keys in the KV store, getObj check if the key has no deployments. it is deleted.
-    await grid.machines.getObj(domainName);
+    await grid.gateway.getObj(domainName);
     return grid.gateway
       .deploy_name(gw)
       .then(() => grid.gateway.getObj(domainName))

--- a/src/utils/deployPresearch.ts
+++ b/src/utils/deployPresearch.ts
@@ -9,28 +9,13 @@ import deploy from "./deploy";
 
 const { MachinesModel, DiskModel, GridClient, MachineModel, generateString } =
   window.configs?.grid3_client ?? {};
-const { HTTPMessageBusClient } = window.configs?.client ?? {};
 
 export default async function deployPresearch(
   data: Presearch,
   profile: IProfile
 ) {
-  const name = data.name;
-  const { mnemonics, storeSecret, networkEnv } = profile;
-
-  const http = new HTTPMessageBusClient(0, "", "", "");
-  const client = new GridClient(
-    networkEnv as any,
-    mnemonics,
-    storeSecret,
-    http,
-    undefined,
-    "tfkvstore" as any
-  );
-
-  await client.connect();
-
-  return await depoloyPresearchVM(data, profile);
+  const deploymentInfo = await depoloyPresearchVM(data, profile);
+  return { deploymentInfo };
 }
 
 async function depoloyPresearchVM(data: Presearch, profile: IProfile) {
@@ -90,7 +75,8 @@ async function depoloyPresearchVM(data: Presearch, profile: IProfile) {
   machines.description = "presearch node";
 
   // Deploy
-  return deploy(profile, "Presearch", name, (grid) => {
+  return deploy(profile, "Presearch", name, async (grid) => {
+    await grid.machines.getObj(name);
     return grid.machines
       .deploy(machines)
       .then(() => grid.machines.getObj(name))

--- a/src/utils/deployPresearch.ts
+++ b/src/utils/deployPresearch.ts
@@ -6,6 +6,7 @@ import createNetwork from "./createNetwork";
 
 import rootFs from "./rootFs";
 import deploy from "./deploy";
+import checkVMExist from "./checkVM";
 
 const { MachinesModel, DiskModel, GridClient, MachineModel, generateString } =
   window.configs?.grid3_client ?? {};
@@ -76,7 +77,8 @@ async function depoloyPresearchVM(data: Presearch, profile: IProfile) {
 
   // Deploy
   return deploy(profile, "Presearch", name, async (grid) => {
-    await grid.machines.getObj(name);
+    await checkVMExist(grid, "presearch", name);
+
     return grid.machines
       .deploy(machines)
       .then(() => grid.machines.getObj(name))

--- a/src/utils/deployTaiga.ts
+++ b/src/utils/deployTaiga.ts
@@ -17,13 +17,7 @@ const {
 
 export default async function deployTaiga(data: Taiga, profile: IProfile) {
   // gateway model: <solution-type><twin-id><solution_name>
-  let domainName = await getUniqueDomainName(
-    "client",
-    "tg",
-    data.name,
-    profile,
-    "Taiga"
-  );
+  let domainName = await getUniqueDomainName(profile, data.name, "Taiga", "tg");
 
   // Dynamically select node to deploy the gateway
   let [publicNodeId, nodeDomain] = await selectGatewayNode();

--- a/src/utils/deployTaiga.ts
+++ b/src/utils/deployTaiga.ts
@@ -5,6 +5,7 @@ import deploy from "./deploy";
 import { selectGatewayNode, getUniqueDomainName } from "./gatewayHelpers";
 import rootFs from "./rootFs";
 import destroy from "./destroy";
+import checkVMExist from "./checkVM";
 
 const {
   DiskModel,
@@ -107,8 +108,8 @@ async function deployTaigaVM(profile: IProfile, data: Taiga) {
   vms.machines = [vm];
 
   return deploy(profile, "Taiga", name, async (grid) => {
-    // For invalidating the cashed keys in the KV store, getObj check if the key has no deployments. it is deleted.
-    await grid.machines.getObj(name);
+    await checkVMExist(grid, "taiga", name);
+
     return grid.machines
       .deploy(vms)
       .then(() => grid.machines.getObj(name))

--- a/src/utils/deployTaiga.ts
+++ b/src/utils/deployTaiga.ts
@@ -4,130 +4,87 @@ import deploy from "./deploy";
 
 import { selectGatewayNode, getUniqueDomainName } from "./gatewayHelpers";
 import rootFs from "./rootFs";
+import destroy from "./destroy";
 
-const { HTTPMessageBusClient } = window.configs?.client ?? {};
 const {
   DiskModel,
   MachineModel,
   MachinesModel,
-  GridClient,
   GatewayNameModel,
   NetworkModel,
   generateString,
 } = window.configs?.grid3_client ?? {};
 
 export default async function deployTaiga(data: Taiga, profile: IProfile) {
-  const { envs, disks:[{size}], adminUsername, adminEmail, adminPassword, smtpFromEmail, smtpHost, smtpPort, smtpHostPassword, smtpHostUser, smtpUseTLS, smtpUseSSL, ...base } = data;
-  let { name, flist, cpu, memory, entrypoint, network: nw } = base;
-  const { publicIp, planetary, nodeId } = base;
-  const { mnemonics, storeSecret, networkEnv, sshKey} = profile;
-
-  const http = new HTTPMessageBusClient(0, "", "", "");
-  const client = new GridClient(
-    networkEnv as any,
-    mnemonics,
-    storeSecret,
-    http,
-    undefined,
-    "tfkvstore" as any
-  );
-
-  await client.connect();
-
-  // sub deployments model (vm, disk, net): <type><random_suffix>
-  let randomSuffix = generateString(10).toLowerCase();
-
   // gateway model: <solution-type><twin-id><solution_name>
-  let domainName = await getUniqueDomainName(client, "tg", name);
+  let domainName = await getUniqueDomainName(
+    "client",
+    "tg",
+    data.name,
+    profile,
+    "Taiga"
+  );
 
   // Dynamically select node to deploy the gateway
   let [publicNodeId, nodeDomain] = await selectGatewayNode();
-  const domain = `${domainName}.${nodeDomain}`;
+  data.domain = `${domainName}.${nodeDomain}`;
+
+  const deploymentInfo = await deployTaigaVM(profile, data);
+
+  const planetaryIP = deploymentInfo["planetary"] as string;
+
+  try {
+    // deploy the gateway
+    await deployPrefixGateway(profile, domainName, planetaryIP, publicNodeId);
+  } catch (error) {
+    // rollback the TaigaVM if the gateway fails to deploy
+    await destroy(profile, "Peertube", data.name);
+    throw error;
+  }
+
+  return { deploymentInfo };
+}
+
+async function deployTaigaVM(profile: IProfile, data: Taiga) {
+  const {
+    name,
+    envs,
+    disks: [{ size }],
+    cpu,
+    memory,
+    publicIp,
+    nodeId,
+    domain,
+    adminUsername,
+    adminEmail,
+    adminPassword,
+    smtpFromEmail,
+    smtpHost,
+    smtpPort,
+    smtpHostPassword,
+    smtpHostUser,
+    smtpUseTLS,
+    smtpUseSSL,
+  } = data;
+
+  // sub deployments model (vm, disk, net): <type><random_suffix>
+  let randomSuffix = generateString(10).toLowerCase();
 
   // define network
   const network = new NetworkModel();
   network.name = `net${randomSuffix}`;
   network.ip_range = "10.1.0.0/16";
 
-  const deployment = await deployTaigaVM(
-    profile,
-    client,
-    name,
-    network,
-    nodeId,
-    cpu,
-    memory,
-    size,
-    domain,
-    adminUsername,
-    adminEmail,
-    adminPassword,
-    sshKey,
-    smtpFromEmail,
-    smtpHost,
-    smtpPort,
-    smtpHostUser,
-    smtpHostPassword,
-    smtpUseTLS,
-    smtpUseSSL,
-    randomSuffix,
-  );
-
-  const info = await getTaigaInfo(client, name);
-  const planetaryIP = info[0]["planetary"];
-
-  try {
-    // deploy the gateway
-    await deployPrefixGateway(
-      profile,
-      client,
-      domainName,
-      planetaryIP,
-      publicNodeId
-    );
-  } catch (error) {
-    // rollback the TaigaVM if the gateway fails to deploy
-    await client.machines.delete({ name: name });
-    throw error;
-  }
-
-  const gatewayInfo = await getGatewayInfo(client, domainName);
-  return { deployment, domain, planetaryIP };
-}
-
-async function deployTaigaVM(
-  profile: IProfile,
-  client: any,
-  name: string,
-  network: any,
-  nodeId: number,
-  cpu: number,
-  memory: number,
-  diskSize: number,
-  domain: string,
-  adminUsername: string,
-  adminEmail: string,
-  adminPassword: string,
-  sshKey: string,
-  smtpFromEmail: string,
-  smtpHost: string,
-  smtpPort: string, 
-  smtpHostUser: string,
-  smtpHostPassword: string,
-  smtpUseTLS,
-  smtpUseSSL,
-  randomSuffix: string,
-) {
   const disk = new DiskModel();
   disk.name = `disk${randomSuffix}`;
-  disk.size = diskSize;
+  disk.size = size;
   disk.mountpoint = "/var/lib/docker";
 
   const vm = new MachineModel();
   vm.name = `vm${randomSuffix}`;
   vm.node_id = nodeId;
   vm.disks = [disk];
-  vm.public_ip = false;
+  vm.public_ip = publicIp;
   vm.planetary = true;
   vm.cpu = cpu;
   vm.memory = memory;
@@ -136,18 +93,18 @@ async function deployTaigaVM(
     "https://hub.grid.tf/samehabouelsaad.3bot/abouelsaad-grid3_taiga_docker-latest.flist";
   vm.entrypoint = "/sbin/zinit init";
   vm.env = {
-    SSH_KEY: sshKey,
+    SSH_KEY: profile.sshKey,
     DOMAIN_NAME: domain,
     ADMIN_USERNAME: adminUsername,
     ADMIN_PASSWORD: adminPassword,
     ADMIN_EMAIL: adminEmail,
     DEFAULT_FROM_EMAIL: smtpFromEmail,
-    EMAIL_USE_TLS: smtpUseTLS ? "True" : "False" ,
-    EMAIL_USE_SSL: smtpUseSSL ? "True": "False",
+    EMAIL_USE_TLS: smtpUseTLS ? "True" : "False",
+    EMAIL_USE_SSL: smtpUseSSL ? "True" : "False",
     EMAIL_HOST: smtpHost,
-    EMAIL_PORT: `${ smtpPort }`,
+    EMAIL_PORT: `${smtpPort}`,
     EMAIL_HOST_USER: smtpHostUser,
-    EMAIL_HOST_PASSWORD: smtpHostPassword
+    EMAIL_HOST_PASSWORD: smtpHostPassword,
   };
 
   const vms = new MachinesModel();
@@ -155,17 +112,11 @@ async function deployTaigaVM(
   vms.network = network;
   vms.machines = [vm];
 
-  return deploy(profile, "Taiga", name, (grid) => {
+  return deploy(profile, "Taiga", name, async (grid) => {
+    // For invalidating the cashed keys in the KV store, getObj check if the key has no deployments. it is deleted.
+    await grid.machines.getObj(name);
     return grid.machines
       .deploy(vms)
-      .then(async () => {
-        for(const gw of await grid.gateway._list()){
-          try {
-            await grid.gateway.getObj(gw);
-          }
-          catch {}
-        }
-      })
       .then(() => grid.machines.getObj(name))
       .then(([vm]) => vm);
   });
@@ -173,7 +124,6 @@ async function deployTaigaVM(
 
 async function deployPrefixGateway(
   profile: IProfile,
-  client: any,
   domainName: string,
   backend: string,
   publicNodeId: number
@@ -184,20 +134,12 @@ async function deployPrefixGateway(
   gw.tls_passthrough = false;
   gw.backends = [`http://[${backend}]:9000/`];
 
-  return deploy(profile, "GatewayName", domainName, (grid) => {
+  return deploy(profile, "GatewayName", domainName, async (grid) => {
+    // For invalidating the cashed keys in the KV store, getObj check if the key has no deployments. it is deleted.
+    await grid.gateway.getObj(domainName);
     return grid.gateway
       .deploy_name(gw)
       .then(() => grid.gateway.getObj(domainName))
       .then(([gw]) => gw);
   });
-}
-
-async function getTaigaInfo(client: any, name: string) {
-  const info = await client.machines.getObj(name);
-  return info;
-}
-
-async function getGatewayInfo(client: any, name: string) {
-  const info = await client.gateway.getObj(name);
-  return info;
 }

--- a/src/utils/destroy.ts
+++ b/src/utils/destroy.ts
@@ -1,0 +1,19 @@
+import type { IProfile } from "../types/Profile";
+import type { IStore } from "../stores/currentDeployment";
+
+export default function destroy(
+  profile: IProfile,
+  type: IStore["type"],
+  name: string
+) {
+  const { networkEnv, mnemonics, storeSecret } = profile;
+  const client = new window.configs.grid3_client.GridClient(
+    networkEnv as any,
+    mnemonics,
+    storeSecret,
+    new window.configs.client.HTTPMessageBusClient(0, "", "", ""),
+    type,
+    window.configs.grid3_client.BackendStorageType.tfkvstore
+  );
+  return client.machines.delete({ name });
+}

--- a/src/utils/gatewayHelpers.ts
+++ b/src/utils/gatewayHelpers.ts
@@ -15,11 +15,10 @@ export async function selectGatewayNode(): Promise<[number, string]> {
 }
 
 export async function getUniqueDomainName(
-  grid,
-  solutionCode,
+  profile,
   name,
-  profile?,
-  solutionType?
+  solutionType,
+  solutionCode
 ) {
   const { networkEnv, mnemonics, storeSecret } = profile;
   const client = new window.configs.grid3_client.GridClient(

--- a/src/utils/gatewayHelpers.ts
+++ b/src/utils/gatewayHelpers.ts
@@ -14,7 +14,24 @@ export async function selectGatewayNode(): Promise<[number, string]> {
   return [nodeId, nodeDomain];
 }
 
-export async function getUniqueDomainName(client, solution_type, name) {
+export async function getUniqueDomainName(
+  grid,
+  solutionCode,
+  name,
+  profile?,
+  solutionType?
+) {
+  const { networkEnv, mnemonics, storeSecret } = profile;
+  const client = new window.configs.grid3_client.GridClient(
+    networkEnv as any,
+    mnemonics,
+    storeSecret,
+    new window.configs.client.HTTPMessageBusClient(0, "", "", ""),
+    solutionType,
+    window.configs.grid3_client.BackendStorageType.tfkvstore
+  );
+
+  await client.connect();
   let twin_id = await client.twins.get_my_twin_id();
-  return `${solution_type}${twin_id}${name.toLowerCase()}`;
+  return `${solutionCode}${twin_id}${name.toLowerCase()}`;
 }

--- a/src/utils/getGrid.ts
+++ b/src/utils/getGrid.ts
@@ -4,7 +4,8 @@ import type { GridClient } from "grid3_client";
 export default async function getGrid<T>(
   profile: IProfile,
   cb: (grid: GridClient) => T,
-  disconnect: boolean = true
+  disconnect: boolean = true,
+  solutionType?: string
 ): Promise<T> {
   const { networkEnv, mnemonics, storeSecret } = profile;
   const grid = new window.configs.grid3_client.GridClient(
@@ -12,7 +13,7 @@ export default async function getGrid<T>(
     mnemonics,
     storeSecret,
     new window.configs.client.HTTPMessageBusClient(0, "", "", ""),
-    undefined,
+    solutionType,
     window.configs.grid3_client.BackendStorageType.tfkvstore
   );
 

--- a/src/utils/getGrid.ts
+++ b/src/utils/getGrid.ts
@@ -13,7 +13,7 @@ export default async function getGrid<T>(
     mnemonics,
     storeSecret,
     new window.configs.client.HTTPMessageBusClient(0, "", "", ""),
-    solutionType,
+    undefined,
     window.configs.grid3_client.BackendStorageType.tfkvstore
   );
 


### PR DESCRIPTION
### Description
Fixing the possible conflicts in naming two VMS by separating the deployments with `projectName` prop while initializing the `GridClient`

### Related Issues
- #378 
