### PR TITLE
use a fixed version for caprover captain image

### DIFF
--- a/src/utils/deployCaprover.ts
+++ b/src/utils/deployCaprover.ts
@@ -41,7 +41,7 @@ export default async function deployCaprover(
   machine.env = {
     SWM_NODE_MODE: "leader",
     CAPROVER_ROOT_DOMAIN: domain,
-    CAPTAIN_IMAGE_VERSION: "v1.2.0",
+    CAPTAIN_IMAGE_VERSION: "v1.2.1",
     PUBLIC_KEY: publicKey,
     DEFAULT_PASSWORD: password,
   };

--- a/src/utils/deployCaprover.ts
+++ b/src/utils/deployCaprover.ts
@@ -41,6 +41,7 @@ export default async function deployCaprover(
   machine.env = {
     SWM_NODE_MODE: "leader",
     CAPROVER_ROOT_DOMAIN: domain,
+    CAPTAIN_IMAGE_VERSION: "v1.2.0",
     PUBLIC_KEY: publicKey,
     DEFAULT_PASSWORD: password,
   };


### PR DESCRIPTION
### Description

This will avoid using "latest" as the default tag, which would make thing broken across different network deployments.

### Changes

* Pass `CAPTAIN_IMAGE_VERSION` when deploying CapRover.

### Related Issues

* #647

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
