### PR TITLE
fix wrong syntax gql query

### DIFF
--- a/src/components/SelectNodeId.svelte
+++ b/src/components/SelectNodeId.svelte
@@ -235,7 +235,7 @@
                   { id: data }
                 )
                   .then(({ nodes: [{ id }] }) => {
-                    return gqlApi<{publicIps: []}>(profile, 'query getIps($id: Int!) { publicIps(where: { contractID_eq: 0, farm: {farmID_eq: $id}}) {id}}', { id }); // prettier-ignore
+                    return gqlApi<{publicIps: []}>(profile, 'query getIps($id: Int!) { publicIps(where: { contractId_eq: 0, farm: {farmID_eq: $id}}) {id}}', { id }); // prettier-ignore
                   })
                   .then(({ publicIps: ips }) => {
                     status = ips.length > 0 ? "valid" : "invalid";


### PR DESCRIPTION
### related issues
- https://github.com/threefoldtech/test_feedback/issues/98

### description
revert changing `contractId_eq` to `contractID_eq`. this check was not changed on the last graphql changes.
