### PR TITLE
Discourse validation added

### DIFF
--- a/src/elements/discourse/Discourse.wc.svelte
+++ b/src/elements/discourse/Discourse.wc.svelte
@@ -63,7 +63,7 @@
   let cpuField: IFormField;
   let memoryField: IFormField;
 
-  $: disabled = ((loading || !data.valid) && !(success || failed)) || !profile || status !== "valid" || isInvalid([...fields, diskField, memoryField, cpuField]); // prettier-ignore
+  $: disabled = ((loading || !data.valid) && !(success || failed)) || !profile || status !== "valid" || isInvalid([...data.smtp.fields,...fields, diskField, memoryField, cpuField]); // prettier-ignore
 
   let message: string;
   let modalData: Object;
@@ -111,7 +111,9 @@
   <form class="box" on:submit|preventDefault={deployDiscourseHandler}>
     <h4 class="is-size-4 mb-4">Deploy a Discourse Instance</h4>
     <p>
-      Discourse is the 100% open source discussion platform built for the next decade of the Internet. Use it as a mailing list, discussion forum, long-form chat room, and more!
+      Discourse is the 100% open source discussion platform built for the next
+      decade of the Internet. Use it as a mailing list, discussion forum,
+      long-form chat room, and more!
       <a
         target="_blank"
         href="https://library.threefold.me/info/manual/#/manual__weblets_discourse"
@@ -154,9 +156,9 @@
           bind:cpu={data.cpu}
           bind:memory={data.memory}
           bind:diskSize={data.disks[0].size}
-          bind:diskField={diskField}
-          bind:cpuField={cpuField}
-          bind:memoryField={memoryField}
+          bind:diskField
+          bind:cpuField
+          bind:memoryField
           {packages}
         />
 

--- a/src/types/discourse.ts
+++ b/src/types/discourse.ts
@@ -2,7 +2,7 @@ import { v4 } from "uuid";
 import isValidInteger from "../utils/isValidInteger";
 import NodeID from "./nodeId";
 import type { IFormField } from ".";
-import { validateEmail, validatePortNumber } from "../utils/validateName";
+import { validateEmail, validatePassword, validatePortNumber } from "../utils/validateName";
 import validateDomainName from "../utils/validateDomainName";
 
 import TweetNACL from "tweetnacl";
@@ -46,6 +46,7 @@ class SMTP {
       symbol: "password",
       placeholder: "Password",
       type: "password",
+      validator: validatePassword,
       invalid: false,
     },
     { label: "Use TLS", symbol: "enableTLS", type: "checkbox" },

--- a/src/utils/validateName.ts
+++ b/src/utils/validateName.ts
@@ -75,4 +75,6 @@ export function validatePreCode(value: string): string | void {
 
 export function validatePassword(value: string): string | void {
   if (value.length < 6) return "Password must be at least 6 characters";
+  if (value.length > 15) return "Password must be less than 15 characters";
+
 }


### PR DESCRIPTION
### Description

Added Validation on the password field. and disabled deploy button when Name, smtp username and port number are invalid.
### Changes
Discourse.wc.svelte
discourse.ts
validateName.ts
### Related Issues

List of related issues
#702

