### PR TITLE
use the disk size from the bind variable

### DIFF
--- a/src/utils/deployDiscourse.ts
+++ b/src/utils/deployDiscourse.ts
@@ -50,7 +50,7 @@ async function depoloyDiscourseVM(data: Discourse, profile: IProfile) {
     cpu,
     memory,
     nodeId,
-    diskSize,
+    disks: [{ size }],
     smtp,
     developerEmail,
     threebotPRKey,
@@ -67,7 +67,7 @@ async function depoloyDiscourseVM(data: Discourse, profile: IProfile) {
   /* Docker disk */
   const disk = new DiskModel();
   disk.name = `disk${randomSuffix}`;
-  disk.size = diskSize;
+  disk.size = size;
   disk.mountpoint = "/var/lib/docker";
 
   const machine = new MachineModel();

--- a/src/utils/deployOwncloud.ts
+++ b/src/utils/deployOwncloud.ts
@@ -58,7 +58,7 @@ async function deployOwncloudVM(profile: IProfile, data: Owncloud) {
     smtpUseSSL,
     cpu,
     memory,
-    diskSize,
+    disks: [{ size }],
     name,
     nodeId,
     domain,
@@ -75,7 +75,7 @@ async function deployOwncloudVM(profile: IProfile, data: Owncloud) {
   // disk
   const disk = new DiskModel();
   disk.name = `disk${randomSuffix}`;
-  disk.size = diskSize;
+  disk.size = size;
   disk.mountpoint = "/var/lib/docker";
 
   // vm specs


### PR DESCRIPTION
### Description

This issue appears only on (Owncloud and Discourse) due to using a different variable for the disk size than the one `SelectCapacity` component bound to it. so whatever package is selected the deployment will take the fixed value of the `diskSize` not the right one at `disks.size`

### Related Issues

- https://github.com/threefoldtech/grid_weblets/issues/736
