### PR TITLE
Smtp fields don't disable deploy button

### DIFF
--- a/src/elements/Mattermost/Mattermost.wc.svelte
+++ b/src/elements/Mattermost/Mattermost.wc.svelte
@@ -97,7 +97,7 @@
   $: disabled =
     data.invalid ||
     data.status !== "valid" ||
-    isInvalid([...smtpFields, ...baseFields, diskField, memoryField, cpuField]);
+    isInvalid([...baseFields, diskField, memoryField, cpuField]);
 
   function onDeployMattermost() {
     loading = true;


### PR DESCRIPTION
### Description

The smtp fields don't disable the deploy button anymore.
### Changes

Removed the smtp fields from the disabled field.
### Related Issues

#707 