### PR TITLE
limit kubernetes memory

### DIFF
--- a/src/elements/kubernetes/Kubernetes.wc.svelte
+++ b/src/elements/kubernetes/Kubernetes.wc.svelte
@@ -23,7 +23,7 @@
     validateCpu,
     validateDisk,
     validateIP,
-    validateMemory,
+    validateKubernetesMemory,
     validateToken,
   } from "../../utils/validateName";
   import { noActiveProfile } from "../../utils/message";
@@ -54,7 +54,7 @@
   const baseFields: IFormField[] = [
     { label: "Name", symbol: "name", placeholder: "Cluster instance name", type: "text", validator: validateName, invalid: false},
     { label: "CPU (Cores)", symbol: "cpu", placeholder: "CPU cores", type: 'number', validator: validateCpu, invalid: false },
-    { label: "Memory (MB)", symbol: "memory", placeholder: "Memory in MB", type: 'number', validator: validateMemory, invalid: false },
+    { label: "Memory (MB)", symbol: "memory", placeholder: "Memory in MB", type: 'number', validator: validateKubernetesMemory, invalid: false },
     { label: "Disk Size (GB)", symbol: "diskSize", placeholder: "Disk size in GB", type: 'number', validator: validateDisk, invalid: false },
     { label: "Public IPv4", symbol: "publicIp", type: 'checkbox' },
     { label: "Public IPv6", symbol: "publicIp6", type: 'checkbox' },

--- a/src/utils/validateName.ts
+++ b/src/utils/validateName.ts
@@ -50,6 +50,14 @@ export function validateMemory(value: number): string | void {
   if (value > 256 * 1024) return "Maximum allowed memory is 256 GB.";
 }
 
+export function validateKubernetesMemory(value: number): string | void {
+  value = +value;
+  if (isNaN(value)) return "Memory must be a valid number.";
+  if (+value.toFixed(0) !== value) return "Memory must be a valid integer.";
+  if (value < 1024) return "Minimum allowed memory is 1024 MB.";
+  if (value > 256 * 1024) return "Maximum allowed memory is 256 GB.";
+}
+
 export function validateDisk(value: number): string | void {
   value = +value;
   if (isNaN(value)) return "Disk size must be a valid number.";


### PR DESCRIPTION
### Description

kubernetes memory allowed input smaller than 1024 MB and kubernetes server needs that limit to start correctly

### Changes

changed the validator of the memory related to kubernetes only

### Related Issues

#752 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
