### PR TITLE
separate optional smtp password from required alphanumeric db password

### DIFF
--- a/src/elements/Mattermost/Mattermost.wc.svelte
+++ b/src/elements/Mattermost/Mattermost.wc.svelte
@@ -17,7 +17,7 @@
     isInvalid,
     validatePortNumber,
     validateOptionalEmail,
-    validatePassword,
+    validateOptionalPassword,
   } from "../../utils/validateName";
   import validateDomainName from "../../utils/validateDomainName";
   import SelectCapacity from "../../components/SelectCapacity.svelte";
@@ -52,9 +52,9 @@
     },
     {
       label: "SMTP Password",
-      symbol: "password",
+      symbol: "smtpPassword",
       type: "password",
-      validator: validatePassword,
+      validator: validateOptionalPassword,
       placeholder: "SMTP Password",
       invalid: false,
     },

--- a/src/types/mattermost.ts
+++ b/src/types/mattermost.ts
@@ -8,6 +8,7 @@ interface IMattermost {
   name: string;
   username: string;
   password: string;
+  smtpPassword: string;
   nodeId: number;
   domain: string;
   server: string;
@@ -23,6 +24,7 @@ export default class Mattermost implements IMattermost {
   username: string;
   password: string;
   nodeId: number;
+  smtpPassword: string;
   domain: string;
   server: string;
   port: string;
@@ -39,10 +41,12 @@ export default class Mattermost implements IMattermost {
     domain,
     server,
     port,
+    smtpPassword,
   }: Partial<IMattermost> = {}) {
     this.name = name || "mm" + this.id.split("-")[0];
     this.username = username || "";
-    this.password = password || generatePassword(10);
+    this.password = password || this.id.split("-")[0];
+    this.smtpPassword = smtpPassword || generatePassword(10);
     this.nodeId = nodeId;
     this.domain = domain || "";
     this.server = server || "smtp.gmail.com";
@@ -59,7 +63,7 @@ export default class Mattermost implements IMattermost {
       // // domain.trim() === "" ||
       // server.trim() === "" ||
       // port.trim() === "" ||
-      !isValidInteger(port.trim()) ||
+      // !isValidInteger(port.trim()) ||
       !isValidInteger(nodeId)
     );
   }

--- a/src/utils/deployMattermost.ts
+++ b/src/utils/deployMattermost.ts
@@ -57,6 +57,7 @@ function _deployMatterMost(profile: IProfile, mattermost: Mattermost) {
     memory,
     disks,
     publicIp,
+    smtpPassword
   } = mattermost;
 
   let randomSuffix = generateString(10).toLowerCase();
@@ -77,7 +78,7 @@ function _deployMatterMost(profile: IProfile, mattermost: Mattermost) {
     DB_PASSWORD: password,
     SITE_URL: "https://" + domain,
     SMTPUsername: username,
-    SMTPPassword: password,
+    SMTPPassword: smtpPassword,
     SMTPServer: server,
     SMTPPort: port,
     SSH_KEY: profile.sshKey,


### PR DESCRIPTION
### Description

after some debugging, found the same password was used as the DB password and SMTP password. and as DB password is required to be alphanumeric otherwise it will fail starting the server and that caused the `Bad Gateway` error.

### Changes

- separate db password and smtp password.
- make smtp password optional.
- create a random db password.

### Related Issues

- https://github.com/threefoldtech/grid_weblets/issues/716
