### PR TITLE
Smtp fields disables deploy button on error

### DIFF
--- a/src/elements/Mattermost/Mattermost.wc.svelte
+++ b/src/elements/Mattermost/Mattermost.wc.svelte
@@ -97,7 +97,7 @@
   $: disabled =
     data.invalid ||
     data.status !== "valid" ||
-    isInvalid([...baseFields, diskField, memoryField, cpuField]);
+    isInvalid([...baseFields, diskField, memoryField, cpuField, ...smtpFields]);
 
   function onDeployMattermost() {
     loading = true;

--- a/src/elements/vm/Vm.wc.svelte
+++ b/src/elements/vm/Vm.wc.svelte
@@ -111,7 +111,6 @@
   const validateFlist = {
     loading: false,
     error: null,
-    validator: validateFlistvalue,
     invalid: false,
   };
 

--- a/src/elements/vm/Vm.wc.svelte
+++ b/src/elements/vm/Vm.wc.svelte
@@ -111,6 +111,7 @@
   const validateFlist = {
     loading: false,
     error: null,
+    validator: validateFlistvalue,
     invalid: false,
   };
 


### PR DESCRIPTION
### Description
The smtp fields are now optional but disable the deploy button when there's an error message.
### Changes

I added the smtp fields to the disabled variable.
### Related Issues

#707