### PR TITLE
Change name of tabs from 'TFhubValidator' to 'TFhub Validator'

### DIFF
--- a/playground/src/views/Editor.vue
+++ b/playground/src/views/Editor.vue
@@ -141,7 +141,7 @@ export default class Editor extends Vue {
       "mattermost.png"
     ),
     new Weblet(
-      "TFhubValidator",
+      "TFhub Validator",
       "vaildator",
       "tfhubValidator",
       "deployment",

--- a/src/elements/DeployedList/DeployedList.wc.svelte
+++ b/src/elements/DeployedList/DeployedList.wc.svelte
@@ -14,7 +14,7 @@
     | "funkwhale"
     | "peertube"
     | "mattermost"
-    | "tfhubValidator"
+    | "tfhub Validator"
     | "discourse"
     | "taiga"
     | "owncloud"
@@ -380,7 +380,6 @@
       },
     }
   );
-  
 </script>
 
 <SelectProfile

--- a/src/elements/TFhubValidator/TFhubValidator.wc.svelte
+++ b/src/elements/TFhubValidator/TFhubValidator.wc.svelte
@@ -121,9 +121,9 @@
 
 <div style="padding: 15px;">
   <form class="box" on:submit|preventDefault={onDeployTFhubValidator}>
-  <h4 class="is-size-4">Deploy a TFhubValidator Instance</h4>
+  <h4 class="is-size-4">Deploy a TFhub Validator Instance</h4>
   <p>
-    TFhubValidator A single point of collaboration. Designed specifically for
+    TFhub Validator A single point of collaboration. Designed specifically for
     digital operations.
     <a
       target="_blank"

--- a/src/utils/deployTFhubValidator.ts
+++ b/src/utils/deployTFhubValidator.ts
@@ -7,6 +7,7 @@ import createNetwork from "./createNetwork";
 import deploy from "./deploy";
 import rootFs from "./rootFs";
 import checkVMExist from "./prepareDeployment";
+import hex from "./hex";
 
 function getNetwork() :string {
   const networks = ['dev', 'qa', 'test', 'main'];
@@ -112,7 +113,7 @@ function _deployTfHubValidator(
     STAKE_AMOUNT: stakeAmount,
     ETHEREUM_ADDRESS: ethereumAddress,
     ETHEREUM_PRIV_KEY: ethereumPrivKey,
-    KEYNAME: v4().split("-")[0],
+    KEYNAME: hex(v4().split("-")[0]),
     MONIKER: v4().split("-")[0],
     CHAIN_ID: defaultEnvVars(getNetwork()).chainId,
     GRAVITY_ADDRESS: defaultEnvVars(getNetwork()).gravityAddress,

--- a/src/utils/hex.ts
+++ b/src/utils/hex.ts
@@ -1,0 +1,7 @@
+export default function hex(str: string): string {
+    var result = '';
+    for (var i=0; i<str.length; i++) {
+      result += str.charCodeAt(i).toString(16);
+    }
+    return result;
+  }


### PR DESCRIPTION

### Description

there is an error that happened while I trying to deploy a new validator, after syncing the node got a KeyName error related to `bech32`, after some searching, I understood that `should be hex`, so a new function was added to the code to convert a string to hex after generated

### Related Issues

[Threefold validators solution](https://github.com/threefoldtech/grid_weblets/issues/631)