### PR TITLE
add a direct link for the node pilot - flist

### DIFF
--- a/src/elements/DeployedList/DeployedList.wc.svelte
+++ b/src/elements/DeployedList/DeployedList.wc.svelte
@@ -383,6 +383,18 @@
           disabled: () => removing !== null,
           loading: (i) => removing === rows[i].name,
         },
+        {
+          type: "warning",
+          label: "Visit",
+          click: (_, i) => {
+            const domain = rows[i].details.publicIP.ip;
+            window.open("https://" + domain.substr(0, domain.indexOf('/')), "_blank").focus();
+          },
+          disabled: (i) => {
+            const publicIP = rows[i].details.publicIP;
+            return !publicIP || !publicIP.ip || removing !== null;
+          },
+        },
       ],
     },
     {

--- a/src/elements/nodePilot/NodePilot.wc.svelte
+++ b/src/elements/nodePilot/NodePilot.wc.svelte
@@ -19,14 +19,14 @@
   import hasEnoughBalance from "../../utils/hasEnoughBalance";
   import validateName, {
     isInvalid,
-    validateCpu,
+    validateNPCpu,
     validateFlistvalue,
     validateKey,
     validateKeyValue,
-    validateMemory,
+    validateNPMemory,
   } from "../../utils/validateName";
   import { noActiveProfile } from "../../utils/message";
-
+  
   const tabs: ITab[] = [
     { label: "Config", value: "config" }
   ];
@@ -35,20 +35,19 @@
 
   // prettier-ignore
   let baseFields: IFormField[] = [
-    { label: "CPU (Cores)", symbol: 'cpu', placeholder: 'CPU Cores', type: 'number', validator: validateCpu, invalid: false},
-    { label: "Memory (MB)", symbol: 'memory', placeholder: 'Your Memory in MB', type: 'number', validator: validateMemory, invalid: false },
+    { label: "CPU (Cores)", symbol: 'cpu', placeholder: 'CPU Cores', type: 'number', validator: validateNPCpu, invalid: false},
+    { label: "Memory (MB)", symbol: 'memory', placeholder: 'Your Memory in MB', type: 'number', validator: validateNPMemory, invalid: false },
     ];
 
   const nameField: IFormField = { label: "Name", placeholder: "Node Pilot Name", symbol: "name", type: "text", validator: validateName, invalid: false }; // prettier-ignore
 
   // prettier-ignore
   const flists: IFlist[] = [
-    { name: "nodepilot", url: "https://hub.grid.tf/maxux42.3bot/maxux-nodep.flist", entryPoint: "/" },
+    { name: "nodepilot", url: "https://hub.grid.tf/tf-official-vms/node-pilot-zdbfs.flist", entryPoint: "/" },
     
   ];
 
   $: {
-    data.name = "np" + data.id.split("-")[0],
     data.flist = flists[0].url;
     data.entrypoint = flists[0].entryPoint;
     data.cpu = 8;

--- a/src/utils/validateName.ts
+++ b/src/utils/validateName.ts
@@ -55,6 +55,11 @@ export function validateMemory(value: number): string | void {
   if (value > 256 * 1024) return "Maximum allowed memory is 256 GB.";
 }
 
+export function validateNPMemory(value: number): string | void {
+  if (value < 8192) return "Minimum allowed memory is 8192 MB.";
+  return validateMemory(value);
+}
+
 export function validateKubernetesMemory(value: number): string | void {
   if (!NUM_REGEX.test(value.toString()) || isNaN(+value))
     return "Memory must be a valid number.";
@@ -80,6 +85,11 @@ export function validateCpu(value: number): string | void {
   if (+value.toFixed(0) !== value) return "CPU cores must be a valid integer.";
   if (value < 1) return "Minimum allowed CPU cores is 1.";
   if (value > 32) return "Maximum allowed CPU cores is 32.";
+}
+
+export function validateNPCpu(value: number): string | void {
+  if (value < 8) return "Minimum allowed CPU cores is 8.";
+  return validateCpu(value);
 }
 
 export function validatePortNumber(value: string): string | void {


### PR DESCRIPTION
### Description

- Didn't know how to open the node pilot deployment.
- Flist was not official
- the fields was not changeable

### Changes

- Adding a direct link to open the node pilot solution from its deployment list.
- Added an official flist
- allowed change for the input fields

### Related Issues

#825 
#841 
#838 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
