### PR TITLE
fix ip range - master node starts with MR

### DIFF
--- a/src/elements/kubernetes/Kubernetes.wc.svelte
+++ b/src/elements/kubernetes/Kubernetes.wc.svelte
@@ -47,7 +47,7 @@
   // prettier-ignore
   const networkFields: IFormField[] = [
     { label: "Network Name", symbol: "name", placeholder: "Network Name", type: "text", validator: validateName , invalid: false},
-    { label: "Network IP Range", symbol: "ipRange", placeholder: "Network IP Range", type: "text", validator: validateIPRange, invalid: false },
+    { label: "Network IP Range", symbol: "ipRange", placeholder: "xxx.xx.xx.xx/16", type: "text", validator: validateIPRange, invalid: false },
   ];
 
   // prettier-ignore

--- a/src/types/kubernetes.ts
+++ b/src/types/kubernetes.ts
@@ -36,7 +36,10 @@ export abstract class Base {
   }
 }
 
-export class Master extends Base { }
+export class Master extends Base { 
+  public id = v4();
+  public name: string = "MR" + this.id.split("-")[0];
+ }
 export class Worker extends Base { }
 
 export class Network {

--- a/src/utils/validateName.ts
+++ b/src/utils/validateName.ts
@@ -2,7 +2,7 @@ import type { IFormField } from "../types";
 
 const PRECODE_REGEX = /[a-zA-Z0-9]{32}$/;
 const ALPHA_NUMS_ONLY_REGEX = /^\w+$/;
-const IP_REGEX = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}\/[0-9]{1,3}$/;
+const IP_REGEX = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}\/16$/;
 const EMAIL_REGEX = /^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})$/;
 // const UNIX_PATH_REGEX = /^\/([A-z0-9-_+]+\/)*([A-z0-9]+)$/;
 const ALPHA_ONLY_REGEX = /[A-Za-z]/; // Alphabets only
@@ -144,8 +144,8 @@ export function validateToken(token: string): string | void {
 }
 
 export function validateIPRange(value: string): string | void {
-  if (!IP_REGEX.test(value)) return "Invalid IP range.";
-  if (value.length > 15) return "Password must be less than 15 characters";
+  if (!IP_REGEX.test(value)) return "Invalid IP range. IP address in CIDR format xxx.xx.xx.xx/16";
+  if (value.length > 15) return "IP range must be less than 15 characters";
 }
 
 export function validateMountPoint(value: string): string | void {


### PR DESCRIPTION
### Description

- some IP range cases are accepted before deployment but cause errors
- master node name starts with WR

### Changes

- change the place holder and the validation of IP range field
- master node name starts with MR

### Related Issues

#863
#859 