### PR TITLE
change network for every deployment

### DIFF
--- a/src/utils/createNetwork.ts
+++ b/src/utils/createNetwork.ts
@@ -1,8 +1,7 @@
-import { Network } from "../types/kubernetes";
+import type { Network } from "../types/kubernetes";
 const { NetworkModel } = window.configs?.grid3_client ?? {};
 
 export default function createNetwork(nw: Network, access: boolean = false) {
-  nw = new Network();
   const network = new NetworkModel();
   network.name = nw.name;
   network.ip_range = nw.ipRange;

--- a/src/utils/createNetwork.ts
+++ b/src/utils/createNetwork.ts
@@ -1,7 +1,8 @@
-import type { Network } from "../types/kubernetes";
+import { Network } from "../types/kubernetes";
 const { NetworkModel } = window.configs?.grid3_client ?? {};
 
 export default function createNetwork(nw: Network, access: boolean = false) {
+  nw = new Network();
   const network = new NetworkModel();
   network.name = nw.name;
   network.ip_range = nw.ipRange;

--- a/src/utils/deployKubernetes.ts
+++ b/src/utils/deployKubernetes.ts
@@ -1,4 +1,5 @@
-import { default as Kubernetes, Base, Network } from "../types/kubernetes";
+import type { default as Kubernetes, Base } from "../types/kubernetes";
+import { Network } from "../types/kubernetes";
 import type { IProfile } from "../types/Profile";
 import createNetwork from "./createNetwork";
 import deploy from "./deploy";

--- a/src/utils/deployKubernetes.ts
+++ b/src/utils/deployKubernetes.ts
@@ -1,4 +1,4 @@
-import type { default as Kubernetes, Base } from "../types/kubernetes";
+import { default as Kubernetes, Base, Network } from "../types/kubernetes";
 import type { IProfile } from "../types/Profile";
 import createNetwork from "./createNetwork";
 import deploy from "./deploy";
@@ -17,7 +17,7 @@ export default async function deployKubernetes(
   const k8s = new K8SModel();
   k8s.name = name;
   k8s.secret = secret;
-  k8s.network = createNetwork(nw, true);
+  k8s.network = createNetwork(new Network(), true);
   k8s.masters = masterNodes;
   k8s.workers = workerNodes;
   k8s.metadata = metadata;

--- a/src/utils/deployVM.ts
+++ b/src/utils/deployVM.ts
@@ -6,6 +6,7 @@ import type { IProfile } from "../types/Profile";
 import deploy from "./deploy";
 import type { IStore } from "../stores/currentDeployment";
 import checkVMExist from "./prepareDeployment";
+import { Network } from "../types/kubernetes";
 
 export default async function deployVM(data: VM, profile: IProfile, type: IStore["type"]) {
   const { envs, disks, rootFs, ...base } = data;
@@ -28,7 +29,7 @@ export default async function deployVM(data: VM, profile: IProfile, type: IStore
 
   const vms = new MachinesModel();
   vms.name = name;
-  vms.network = createNetwork(nw);
+  vms.network = createNetwork(new Network());
   vms.machines = [vm];
 
   return deploy(profile, type, name, async (grid) => {


### PR DESCRIPTION
### Description

- network doe not change when the user click back and deploy another instance

### Changes

- create a new network for any deployment

### Related Issues

- https://github.com/threefoldtech/grid_weblets/issues/881
