### PR TITLE
Updated The quick start documentation link to the correct node pilot …

### DIFF
--- a/src/elements/nodePilot/NodePilot.wc.svelte
+++ b/src/elements/nodePilot/NodePilot.wc.svelte
@@ -166,7 +166,7 @@
       Deploy a new Node Pilot on the Threefold Grid
       <a
         target="_blank"
-        href="https://library.threefold.me/info/manual/#/manual__weblets_vm"
+        href="https://library.threefold.me/info/manual/#/manual__weblets_nodepilot"
       >
         Quick start documentation</a
       >


### PR DESCRIPTION

### Description

the link in the top of the node pilot weblet refer to the VM doc, so the incorrect link was exchanged for the correct link

### Changes

Edited a reference link in node pilot file.
### Related Issues

#924