### PR TITLE
disable deploy button if no net is selected - change delete selected background color - change password error msg

### DIFF
--- a/src/elements/ContractsList/ContractsList.wc.svelte
+++ b/src/elements/ContractsList/ContractsList.wc.svelte
@@ -193,7 +193,7 @@
           <button
             class={"button is-danger is-outlined mr-2 " +
               (deleting && deletingType === "selected" ? "is-loading" : "")}
-            style={`border-color: #FF5151; color: #FF5151;`}
+            style={`border-color: #FF5151; color: #FF5151; background: white;`}
             disabled={!profile ||
               loading ||
               deleting ||

--- a/src/elements/profiles/Profiles.wc.svelte
+++ b/src/elements/profiles/Profiles.wc.svelte
@@ -66,7 +66,7 @@
     //   { label: "Testnet", value: "test" },
     //   { label: "Devnet", value: "dev" }
     // ] },
-    { label: "Mnemonics", symbol: "mnemonics", placeholder: "Enter Your Mnemonics", type: "password" },
+    { label: "Mnemonics", symbol: "mnemonics", placeholder: "Enter Your Polkadot Mnemonics or TFChain secret", type: "password" },
     // { label: "TFChain Configurations Secret", symbol: "storeSecret", placeholder: "  Secret key used to encrypt your data on TFChain", type: "password" },
     { label: "Public SSH Key", symbol: "sshKey", placeholder: "Your public SSH key will be added as default to all deployments.", type: "text" },
   ];

--- a/src/elements/vm/Vm.wc.svelte
+++ b/src/elements/vm/Vm.wc.svelte
@@ -108,7 +108,7 @@
     return mounts.length !== mountSet.size || names.length !== nameSet.size;
   }
 
-  $: disabled = ((loading || !data.valid) && !(success || failed)) || !profile || status !== "valid" || validateFlist.invalid || nameField.invalid || isInvalid([...baseFields,...envFields]) || _isInvalidDisks(); // prettier-ignore
+  $: disabled = ((loading || !data.valid) && !(success || failed)) || !profile || status !== "valid" || validateFlist.invalid || nameField.invalid || isInvalid([...baseFields,...envFields]) || _isInvalidDisks() || !(data.planetary || data.publicIp || data.publicIp6); // prettier-ignore
   const currentDeployment = window.configs?.currentDeploymentStore;
   const validateFlist = {
     loading: false,

--- a/src/utils/validateName.ts
+++ b/src/utils/validateName.ts
@@ -128,7 +128,7 @@ export function validateProfileName(name: string): string | void {
 
 export function validatePassword(value: string): string | void {
   if (value.length < 6) return "Password must be at least 6 characters";
-  if (value.length > 15) return "Password must be at least 15 characters";
+  if (value.length > 15) return "Password must be less than 15 characters";
 }
 
 export function validateRequiredPassword(value: string): string | void {


### PR DESCRIPTION
### Description

- VM can be deployed without (IPv4, IPv6, Planetary) 
- delete selected button in contracts list has a wrong background color
- password msg was wrong if it is > 15 `Password must be at least 15 characters`
- Mnemonics field placeholder needs to be more clear

### Changes

-  required at least one of them (IPv4, IPv6, Planetary)
- change delete selected button background color
- password msg is changed to `Password must be less than 15 characters`
- change Mnemonics field place holder field from `Enter Your Mnemonics` to `Enter Your Polkadot Mnemonics or TFChain secret`

### Related Issues

- https://github.com/threefoldtech/grid_weblets/issues/824
- https://github.com/threefoldtech/grid_weblets/issues/925
- https://github.com/threefoldtech/grid_weblets/issues/918
- https://github.com/threefoldtech/grid_weblets/issues/711