### PR TITLE
hot fixes for presearch

### DIFF
--- a/src/elements/presearch/Presearch.wc.svelte
+++ b/src/elements/presearch/Presearch.wc.svelte
@@ -164,7 +164,7 @@
           {profile}
           on:fetch={({ detail }) => (data.selection.nodes = detail)}
           nodes={data.selection.nodes}
-          exclusiveFor="presearch"
+          exclusiveFor="research"
         />
       {:else if active === "restore"}
         <div class="notification is-warning is-light">

--- a/src/utils/deployPresearch.ts
+++ b/src/utils/deployPresearch.ts
@@ -74,7 +74,6 @@ async function depoloyPresearchVM(data: Presearch, profile: IProfile) {
   machines.machines = [machine];
   machines.network = network;
   machines.description = "presearch node";
-  machines.metadata = "presearch"
 
   const metadate = {
     "type":  "vm",  

--- a/src/utils/findNodes.ts
+++ b/src/utils/findNodes.ts
@@ -68,9 +68,10 @@ async function getBlockedNodesIDs(
   // For now, it is only used with presearch.
   const gqlClient = new Graphql(graphql);
 
-  const farmIdsarr = await getBlockedFarmsIDs(exclusiveFor, rmbProxy, graphql);
+  let farmIdsarr: any = await getBlockedFarmsIDs(exclusiveFor, rmbProxy, graphql);
 
   // get all the nodeIds of all the farms
+  farmIdsarr = `[${farmIdsarr.join(", ")}]`;
   const res = await gqlClient.query(
     `query MyQuery {
       nodes(where: {farmID_in: ${farmIdsarr}}) {

--- a/src/utils/findNodes.ts
+++ b/src/utils/findNodes.ts
@@ -68,20 +68,19 @@ async function getBlockedNodesIDs(
   // For now, it is only used with presearch.
   const gqlClient = new Graphql(graphql);
 
-  let farmIdsarr: any = await getBlockedFarmsIDs(exclusiveFor, rmbProxy, graphql);
+  let blockedFarmsIDs = await getBlockedFarmsIDs(exclusiveFor, rmbProxy, graphql);
 
   // get all the nodeIds of all the farms
-  farmIdsarr = `[${farmIdsarr.join(", ")}]`;
+  let farmsIDs = `[${blockedFarmsIDs.join(", ")}]`;
   const res = await gqlClient.query(
     `query MyQuery {
-      nodes(where: {farmID_in: ${farmIdsarr}}) {
+      nodes(where: {farmID_in: ${farmsIDs}}) {
         nodeID
       }
     }`
   );
   let farmNodesIDs = [...res.data["nodes"]];
 
-  console.log({farmNodesIDs})
   return farmNodesIDs;
 }
 
@@ -89,7 +88,7 @@ export async function getBlockedFarmsIDs(
   exclusiveFor: string,
   rmbProxy: string,
   graphql: string
-) {
+) : Promise<number[]> {
   const gqlClient = new Graphql(graphql);
 
   // get the total number of deployment of the same type
@@ -109,7 +108,7 @@ export async function getBlockedFarmsIDs(
   const nodeIds = res2.data.nodeContracts.map((n) => n.nodeID);
 
   // get the farmIds of all the used nodes. "in Set to remove duplicates"
-  let farmIds = new Set();
+  let farmIds = new Set<number>();
   for (let nodeId of nodeIds) {
     const res = await fetch(`${rmbProxy}/nodes/${nodeId}`);
     farmIds.add((await res.json())["farmId"]);


### PR DESCRIPTION
### Description

- remove the `p` from 'presearch` in `exclusiveFor` value to match the old and new metadata with both capital and small `p` letter
- stringify the blocked farm ids list to fix the graphql call

### Related issues
- https://github.com/threefoldtech/grid_weblets/issues/665