### PR TITLE
Editing endpoint regex to reject special chars at the end

### DIFF
--- a/src/elements/subsquid/Subsquid.wc.svelte
+++ b/src/elements/subsquid/Subsquid.wc.svelte
@@ -63,7 +63,7 @@ import SelectCapacity from "../../components/SelectCapacity.svelte";
     { label: "Public IP", symbol: "publicIp", placeholder: "Enable Public Ip", type: 'checkbox' },
   ];
 
-  $: disabled = ((loading || !data.valid) && !(success || failed)) || invalid || !profile || status !== "valid" || isInvalid([...fields]); // prettier-ignore
+  $: disabled = ((loading || !data.valid) && !(success || failed)) || invalid || !profile || status !== "valid" || isInvalid([...fields, diskField, cpuField, memoryField]); // prettier-ignore
 
   let message: string;
   let modalData: Object;

--- a/src/utils/validateName.ts
+++ b/src/utils/validateName.ts
@@ -19,7 +19,7 @@ const NUM_REGEX = /^[1-9](\d?|\d+)$/;
 const SSH_REGEX =
   /^(sk-)?(ssh-rsa AAAAB3NzaC1yc2|ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT|ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD|ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj|ssh-ed25519 AAAAC3NzaC1lZDI1NTE5|ssh-dss AAAAB3NzaC1kc3)[0-9A-Za-z+/]+[=]{0,3}( .*)?$/;
 
-const ENDPOINT_REGEX = /^(wss:\/\/)[\w.-]+(?:\.[\w\.-]+)+[\w\-\./\$]+[^\W\s]$/;
+const ENDPOINT_REGEX = /^((?:wss):\/\/)(([a-z0-9]+[.][a-z]){1,3}([a-z-/]?[^\W\s]){1,10})$/;
 
 // prettier-ignore
 export default function validateName(name: string): string | void {

--- a/src/utils/validateName.ts
+++ b/src/utils/validateName.ts
@@ -19,7 +19,7 @@ const NUM_REGEX = /^[1-9](\d?|\d+)$/;
 const SSH_REGEX =
   /^(sk-)?(ssh-rsa AAAAB3NzaC1yc2|ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT|ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD|ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj|ssh-ed25519 AAAAC3NzaC1lZDI1NTE5|ssh-dss AAAAB3NzaC1kc3)[0-9A-Za-z+/]+[=]{0,3}( .*)?$/;
 
-const ENDPOINT_REGEX = /^(((?:wss):\/\/)[a-z0-9-.]+\.[a-z]{2,4}\/?([\w-])?)/;
+const ENDPOINT_REGEX = /^(wss:\/\/)[\w.-]+(?:\.[\w\.-]+)+[\w\-\./\$]+[^\W\s]$/;
 
 // prettier-ignore
 export default function validateName(name: string): string | void {


### PR DESCRIPTION
### Description

Editing endpoint regex to reject special chars at the end

### Changes

changing endpoint regex in validateName.ts & disabling deploy button on invalid fields in subsquid.svelte

### Related Issues
https://github.com/threefoldtech/grid_weblets/issues/1005


List of related issues
- https://github.com/threefoldtech/grid_weblets/issues/1005

