### PR TITLE
Upgrading ubuntu flist in vm to 22.4

### DIFF
--- a/src/elements/vm/Vm.wc.svelte
+++ b/src/elements/vm/Vm.wc.svelte
@@ -51,7 +51,7 @@
 
   // prettier-ignore
   const flists: IFlist[] = [
-    { name: "Ubuntu", url: "https://hub.grid.tf/tf-official-apps/threefoldtech-ubuntu-20.04.flist", entryPoint: "/init.sh" },
+    { name: "Ubuntu-22.04", url: "https://hub.grid.tf/tf-official-vms/ubuntu-22.04.flist", entryPoint: "/init.sh" },
     { name: "Alpine", url: "https://hub.grid.tf/tf-official-apps/threefoldtech-alpine-3.flist", entryPoint: "/entrypoint.sh" },
     { name: "CentOS", url: "https://hub.grid.tf/tf-official-apps/threefoldtech-centos-8.flist", entryPoint: "/entrypoint.sh" },
 


### PR DESCRIPTION
### Description

Upgrade ubuntu flist in VM component to 22.4

### Changes

Edit ubuntu flist in vm component

### Related Issues

- https://github.com/threefoldtech/grid_weblets/issues/1017
