### PR TITLE
Adding calculator base note

### DIFF
--- a/src/elements/FarmingCalculator/FarmingCalculator.wc.svelte
+++ b/src/elements/FarmingCalculator/FarmingCalculator.wc.svelte
@@ -288,6 +288,9 @@
       {#if active === "Basic"}
         <div class="farming-content">
           <div class="farming-content--left">
+            <div class="mb-2">
+              <p><strong>Note:</strong> Make sure to use base 1024 while filling in the simulator, otherwise there might be a different payout.</p>
+            </div>
             {#each basicInputFields as field (field.symbol)}
               {#if !field.only || field.only === activeProfile.name}
                 <div class="field">


### PR DESCRIPTION
### Description

Adding a note in farming calculator to make it clear for the users to enter their inputs in base 1024 to match minting code.

### Changes

- adding a note in farming calculator

### Related Issues

- https://github.com/threefoldtech/grid_weblets/issues/1011

