### PR TITLE
don't exclude exclusive farms if there is ip

### DIFF
--- a/src/utils/fetchFarms.ts
+++ b/src/utils/fetchFarms.ts
@@ -58,18 +58,24 @@ export default function fetchFarms(
     .then(async (vars) => {
       let { farms } = await gqlApi<IQueryData>(profile, queryDataSelect, vars);
 
-      farms = await getOnlineFarms(profile, farms, exclusiveFor);
+      farms = await getOnlineFarms(
+        profile,
+        farms,
+        exclusiveFor,
+        filters.publicIPs
+      );
 
       return { farms };
     });
 }
 
-export async function getOnlineFarms(profile, farms, exclusiveFor) {
+export async function getOnlineFarms(profile, farms, exclusiveFor, publicIp) {
   let blockedFarms = [];
   let onlineFarmsSet = new Set();
   let onlineFarmsArr = [];
 
-  if (exclusiveFor) {
+  if (exclusiveFor && !publicIp) {
+    // no need for exclusive for if we have an ip
     blockedFarms = await getBlockedFarmsIDs(
       exclusiveFor,
       `https://gridproxy.${profile.networkEnv}.grid.tf`,


### PR DESCRIPTION
### Description

Do not exclude the farms that have presearch instances if the deployment has a public IP..

### Changes

- Change the blocking condition

### Related Issues

- https://github.com/threefoldtech/grid_weblets/issues/1013
