### PR TITLE
Fixing SMTP validation

### DIFF
--- a/src/components/Input.svelte
+++ b/src/components/Input.svelte
@@ -163,7 +163,7 @@
         >
           {#if field.type === "textarea"}
             <textarea
-              class={"textarea" + (field.error || _error ? " is-danger" : "")}
+              class={"textarea" + (!field.disabled && (field.error || _error) ? " is-danger" : "")}
               placeholder={field.placeholder}
               bind:value={data}
               on:input={_onInput}
@@ -172,7 +172,7 @@
           {:else if field.type === "text"}
             <input
               type="text"
-              class={"input" + (field.error || _error ? " is-danger" : "")}
+              class={"input" + (!field.disabled && (field.error || _error) ? " is-danger" : "")}
               placeholder={field.placeholder}
               bind:value={data}
               on:input={_onInput}
@@ -182,7 +182,7 @@
             <input
               type="text"
               data-type="number"
-              class={"input" + (field.error || _error ? " is-danger" : "")}
+              class={"input" + (!field.disabled && (field.error || _error) ? " is-danger" : "")}
               placeholder={field.placeholder}
               bind:value={numericData}
               on:input={_onInput}
@@ -194,7 +194,7 @@
           {:else if field.type === "password"}
             <input
               type="password"
-              class={"input" + (field.error || _error ? " is-danger" : "")}
+              class={"input" + (!field.disabled && (field.error || _error) ? " is-danger" : "")}
               placeholder={field.placeholder}
               bind:value={data}
               on:input={_onInput}
@@ -214,7 +214,7 @@
             </span>
           {/if}
         </div>
-        {#if field.error || _error}
+        {#if !field.disabled && (field.error || _error)}
           <p class="help is-danger">
             {field.error || _error}
           </p>
@@ -242,7 +242,7 @@
         <p class="label">{field.label}</p>
       {/if}
       <div
-        class={"select mb-2" + (field.error || _error ? " is-danger" : "")}
+        class={"select mb-2" + (!field.disabled && (field.error || _error) ? " is-danger" : "")}
         style="width: 100%;"
         {id}
       >
@@ -262,7 +262,7 @@
             </option>
           {/each}
         </select>
-        {#if field.error || _error}
+        {#if !field.disabled && (field.error || _error)}
           <p class="help is-danger">
             {field.error || _error}
           </p>

--- a/src/elements/Mattermost/Mattermost.wc.svelte
+++ b/src/elements/Mattermost/Mattermost.wc.svelte
@@ -21,8 +21,8 @@
   import validateName, {
     isInvalid,
     validateRequiredEmail,
-    validatePassword,
     validateRequiredPortNumber,
+    validateRequiredPassword,
   } from "../../utils/validateName";
 import { validateRequiredHostName } from "../../utils/validateDomainName";
 import SelectCapacity from "../../components/SelectCapacity.svelte";
@@ -37,6 +37,7 @@ import SelectGatewayNode from "../../components/SelectGatewayNode.svelte";
   const validator = (x: string) => x.trim().length === 0 ? "Value can't be empty." : null; // prettier-ignore
   let gateway: GatewayNodes;
   let invalid = true;
+  let editable= false;
 
   const tabs: ITab[] = [
     { label: "Base", value: "base" },
@@ -62,7 +63,7 @@ import SelectGatewayNode from "../../components/SelectGatewayNode.svelte";
       label: "SMTP Password",
       symbol: "smtpPassword",
       type: "password",
-      validator: validatePassword,
+      validator: validateRequiredPassword,
       placeholder: "SMTP Password",
       invalid: false,
     },
@@ -101,12 +102,13 @@ import SelectGatewayNode from "../../components/SelectGatewayNode.svelte";
   let modalData: Object;
 
   $: disabled =
-    active === "smtp" && isInvalid([...smtpFields]) ||
+    editable && isInvalid([...smtpFields]) ||
     invalid ||
     data.invalid ||
     data.status !== "valid" ||
-    isInvalid([...baseFields]);    
-    
+    selectCapacity.invalid ||
+    isInvalid([...baseFields]);
+
   function onDeployMattermost() {
     loading = true;
     deployMattermost(profile, data, gateway)
@@ -124,7 +126,7 @@ import SelectGatewayNode from "../../components/SelectGatewayNode.svelte";
         loading = false;
       });
   }
-
+  
   $: logs = $currentDeployment;
 </script>
 
@@ -213,11 +215,23 @@ import SelectGatewayNode from "../../components/SelectGatewayNode.svelte";
             SMTP server, you can configure it.
           </p>
         </div>
+        <div class="is-flex is-justify-content-flex-end">
+          <div style="display: inline-block;">
+            <Input
+            bind:data={editable}
+            field={{
+              label: "",
+              symbol: "editable",
+              type: "checkbox",
+            }}
+          />
+          </div>
+        </div>
         {#each smtpFields as field (field.symbol)}
           <Input
             bind:data={data[field.symbol]}
             bind:invalid={field.invalid}
-            {field}
+            field={{...field, disabled: !editable}}
           />
         {/each}
       {/if}

--- a/src/elements/Mattermost/Mattermost.wc.svelte
+++ b/src/elements/Mattermost/Mattermost.wc.svelte
@@ -15,15 +15,14 @@
   import deployMattermost from "../../utils/deployMattermost";
   import validateName, {
     isInvalid,
-    validatePortNumber,
-    validateOptionalEmail,
-    validateOptionalPassword,
+    validateRequiredEmail,
+    validatePassword,
+    validateRequiredPortNumber,
   } from "../../utils/validateName";
-  import validateDomainName from "../../utils/validateDomainName";
-  import SelectCapacity from "../../components/SelectCapacity.svelte";
-  import rootFs from "../../utils/rootFs";
-  import Tabs from "../../components/Tabs.svelte";
-  import AddBtn from "../../components/AddBtn.svelte";
+import { validateRequiredHostName } from "../../utils/validateDomainName";
+import SelectCapacity from "../../components/SelectCapacity.svelte";
+import rootFs from "../../utils/rootFs";
+import Tabs from "../../components/Tabs.svelte";
 import type { GatewayNodes } from "../../utils/gatewayHelpers";
 import SelectGatewayNode from "../../components/SelectGatewayNode.svelte";
 
@@ -51,14 +50,14 @@ import SelectGatewayNode from "../../components/SelectGatewayNode.svelte";
       symbol: "username",
       type: "text",
       placeholder: "SMTP Username",
-      validator: validateOptionalEmail,
-      invalid: false,
+      validator: validateRequiredEmail,
+      invalid: true,
     },
     {
       label: "SMTP Password",
       symbol: "smtpPassword",
       type: "password",
-      validator: validateOptionalPassword,
+      validator: validatePassword,
       placeholder: "SMTP Password",
       invalid: false,
     },
@@ -67,7 +66,7 @@ import SelectGatewayNode from "../../components/SelectGatewayNode.svelte";
       symbol: "server",
       type: "text",
       placeholder: "SMTP server",
-      validator: validateDomainName,
+      validator: validateRequiredHostName,
       invalid: false,
     },
     {
@@ -75,7 +74,7 @@ import SelectGatewayNode from "../../components/SelectGatewayNode.svelte";
       symbol: "port",
       type: "text",
       placeholder: "SMTP Port",
-      validator: validatePortNumber,
+      validator: validateRequiredPortNumber,
       invalid: false,
     },
   ];
@@ -99,11 +98,12 @@ import SelectGatewayNode from "../../components/SelectGatewayNode.svelte";
   let modalData: Object;
 
   $: disabled =
+    active === "smtp" && isInvalid([...smtpFields]) ||
     invalid ||
     data.invalid ||
     data.status !== "valid" ||
-    isInvalid([...baseFields, diskField, memoryField, cpuField, ...smtpFields]);
-
+    isInvalid([...baseFields, diskField, memoryField, cpuField]);    
+    
   function onDeployMattermost() {
     loading = true;
     deployMattermost(profile, data,gateway)

--- a/src/elements/owncloud/Owncloud.wc.svelte
+++ b/src/elements/owncloud/Owncloud.wc.svelte
@@ -19,12 +19,11 @@
   import hasEnoughBalance from "../../utils/hasEnoughBalance";
   import validateName, {
     isInvalid,
-    validateOptionalEmail,
-    validatePortNumber,
-    validateOptionalPassword,
-    validateRequiredPassword
+    validateRequiredPassword,
+    validateRequiredEmail,
+    validateRequiredPortNumber
   } from "../../utils/validateName";
-  import validateDomainName from "../../utils/validateDomainName";
+  import { validateRequiredHostName } from "../../utils/validateDomainName";
 
   import { noActiveProfile } from "../../utils/message";
   import SelectCapacity from "../../components/SelectCapacity.svelte";
@@ -82,39 +81,40 @@ import SelectGatewayNode from "../../components/SelectGatewayNode.svelte";
       symbol: "smtpFromEmail",
       placeholder: "support@example.com",
       type: "text",
-      validator: validateOptionalEmail,
-      invalid: false,
+      validator: validateRequiredEmail,
+      invalid: true,
     },
     {   
       label: "Port",
       symbol: "smtpPort",
       placeholder: "587",
       type: "text",
-      validator: validatePortNumber,
-      invalid: false, 
+      validator: validateRequiredPortNumber,
+      invalid: true, 
     },
     {
       label: "Host Name",
       symbol: "smtpHost",
       placeholder: "smtp.example.com",
       type: "text",
-      validator: validateDomainName,
-      invalid: false,
+      validator: validateRequiredHostName,
+      invalid: true,
     },
     {
       label: "Username",
       symbol: "smtpHostUser",
       placeholder: "user@example.com",
       type: "text",
-      validator: validateOptionalEmail,
-      invalid: false,
+      validator: validateRequiredEmail,
+      invalid: true,
     },
     {
       label: "Password",
       symbol: "smtpHostPassword",
       placeholder: "password",
       type: "password",
-      validator: validateOptionalPassword, invalid: false
+      validator: validateRequiredPassword, 
+      invalid: true
     },
     { label: "Use TLS", symbol: "smtpUseTLS", type: "checkbox" },
     { label: "Use SSL", symbol: "smtpUseSSL", type: "checkbox" },
@@ -130,7 +130,13 @@ import SelectGatewayNode from "../../components/SelectGatewayNode.svelte";
   let cpuField: IFormField;
   let memoryField: IFormField;
 
-  $: disabled = ((loading || !data.valid) && !(success || failed)) || invalid || !profile || status !== "valid" || isInvalid([...mailFields, ...adminFields, nameField, diskField, memoryField, cpuField]); // prettier-ignore
+  $: disabled = 
+  active === "mail" && isInvalid([...mailFields]) ||
+  ((loading || !data.valid) && !(success || failed)) || 
+  invalid || 
+  !profile || 
+  status !== "valid" || 
+  isInvalid([...adminFields, nameField, diskField, memoryField, cpuField]); // prettier-ignore
   const currentDeployment = window.configs?.currentDeploymentStore;
 
   async function onDeployVM() {

--- a/src/elements/owncloud/Owncloud.wc.svelte
+++ b/src/elements/owncloud/Owncloud.wc.svelte
@@ -36,10 +36,9 @@
   import SelectGatewayNode from "../../components/SelectGatewayNode.svelte";
 
   let data = new Owncloud();
-  let domain: string, planetaryIP: string;
   let gateway: GatewayNodes;
   let invalid = true;
-
+  let editable:boolean;
   data.disks = [new Disk()];
   let profile: IProfile;
   let active: string = "base";
@@ -137,7 +136,7 @@
   let memoryField: IFormField;
 
   $: disabled = 
-  active === "mail" && isInvalid([...mailFields]) ||
+  editable && isInvalid([...mailFields]) ||
   ((loading || !data.valid) && !(success || failed)) || 
   invalid || 
   !profile || 
@@ -273,16 +272,27 @@
             know what you’re doing.
           </p>
         </div>
-
+        <div class="is-flex is-justify-content-flex-end">
+          <div style="display: inline-block;">
+            <Input
+            bind:data={editable}
+            field={{
+              label: "",
+              symbol: "editable",
+              type: "checkbox",
+            }}
+          />
+          </div>
+        </div>
         {#each mailFields as field (field.symbol)}
           {#if field.invalid !== undefined}
             <Input
               bind:data={data[field.symbol]}
               bind:invalid={field.invalid}
-              {field}
+              field={{...field, disabled: !editable}}
             />
           {:else}
-            <Input bind:data={data[field.symbol]} {field} />
+            <Input bind:data={data[field.symbol]} field={{...field, disabled: !editable}} />
           {/if}
         {/each}
       {/if}

--- a/src/elements/taiga/Taiga.wc.svelte
+++ b/src/elements/taiga/Taiga.wc.svelte
@@ -38,7 +38,7 @@
   let data = new Taiga();
   let gateway: GatewayNodes;
   let invalid = true;
-
+  let editable:boolean;
   data.disks = [new Disk()];
   let profile: IProfile;
   let active: string = "base";
@@ -139,7 +139,7 @@
   const deploymentStore = window.configs?.deploymentStore;
 
   $: disabled = 
-  active === "mail" && isInvalid([...mailFields]) ||
+  editable && isInvalid([...mailFields]) ||
   ((loading || !data.valid) && !(success || failed)) ||
   invalid || 
   !profile || 
@@ -275,15 +275,27 @@
             know what you’re doing.
           </p>
         </div>
+        <div class="is-flex is-justify-content-flex-end">
+          <div style="display: inline-block;">
+            <Input
+            bind:data={editable}
+            field={{
+              label: "",
+              symbol: "editable",
+              type: "checkbox",
+            }}
+          />
+          </div>
+        </div>
         {#each mailFields as field (field.symbol)}
           {#if field.invalid !== undefined}
             <Input
               bind:data={data[field.symbol]}
               bind:invalid={field.invalid}
-              {field}
+              field={{...field, disabled: !editable}}
             />
           {:else}
-            <Input bind:data={data[field.symbol]} {field} />
+            <Input bind:data={data[field.symbol]} field={{...field, disabled: !editable}} />
           {/if}
         {/each}
       {/if}

--- a/src/elements/taiga/Taiga.wc.svelte
+++ b/src/elements/taiga/Taiga.wc.svelte
@@ -18,14 +18,11 @@
   import hasEnoughBalance from "../../utils/hasEnoughBalance";
   import validateName, {
     isInvalid,
-    validateCpu,
     validateEmail,
-    validateOptionalEmail,
-    validateDisk,
-    validateMemory,
-    validatePortNumber,
     validatePassword,
-    validateOptionalPassword,
+    validateRequiredEmail,
+    validateRequiredPortNumber,
+    validateRequiredPassword,
   } from "../../utils/validateName";
   import { noActiveProfile } from "../../utils/message";
   import validateDomainName from "../../utils/validateDomainName";
@@ -83,8 +80,8 @@ import type { GatewayNodes } from "../../utils/gatewayHelpers";
       symbol: "smtpFromEmail",
       placeholder: "support@example.com",
       type: "text",
-      validator: validateOptionalEmail,
-      invalid: false,
+      validator: validateRequiredEmail,
+      invalid: true,
     },
     {
       label: "Host Name",
@@ -92,31 +89,31 @@ import type { GatewayNodes } from "../../utils/gatewayHelpers";
       placeholder: "smtp.example.com",
       type: "text",
       validator: validateDomainName,
-      invalid: false,
+      invalid: true,
     },
     {
       label: "Port",
       symbol: "smtpPort",
       placeholder: "587",
       type: "text",
-      validator: validatePortNumber,
-      invalid: false,
+      validator: validateRequiredPortNumber,
+      invalid: true,
     },
     {
       label: "User Name",
       symbol: "smtpHostUser",
       placeholder: "user@example.com",
       type: "text",
-      validator: validateOptionalEmail,
-      invalid: false,
+      validator: validateRequiredEmail,
+      invalid: true,
     },
     {
       label: "Password",
       symbol: "smtpHostPassword",
       placeholder: "password",
       type: "password",
-      validator: validateOptionalPassword,
-      invalid: false,
+      validator: validateRequiredPassword,
+      invalid: true,
     },
     { label: "Use TLS", symbol: "smtpUseTLS", type: "checkbox" },
     { label: "Use SSL", symbol: "smtpUseSSL", type: "checkbox" },
@@ -139,7 +136,13 @@ import type { GatewayNodes } from "../../utils/gatewayHelpers";
   let cpuField: IFormField;
   let memoryField: IFormField;
 
-  $: disabled = ((loading || !data.valid) && !(success || failed)) || invalid || !profile || status !== "valid" || isInvalid([...mailFields, ...adminFields, nameField, diskField, memoryField, cpuField, ]); // prettier-ignore
+  $: disabled = 
+  active === "mail" && isInvalid([...mailFields]) ||
+  ((loading || !data.valid) && !(success || failed)) ||
+  invalid || 
+  !profile || 
+  status !== "valid" || 
+  isInvalid([...adminFields, nameField, diskField, memoryField, cpuField]); // prettier-ignore
   const currentDeployment = window.configs?.currentDeploymentStore;
 
   async function onDeployVM() {


### PR DESCRIPTION
### Description

Making all SMTP input validation required but does not work unless the SMTP tab is active

### Changes

Changing validator & making inputs invalid by default in Mattermost, Taiga & Owncloud.

### Related Issues

- https://github.com/threefoldtech/grid_weblets/issues/949
