### PR TITLE
edit Mnemonics placeholder field

### DIFF
--- a/src/elements/profiles/Profiles.wc.svelte
+++ b/src/elements/profiles/Profiles.wc.svelte
@@ -94,7 +94,7 @@
     //   { label: "Testnet", value: "test" },
     //   { label: "Devnet", value: "dev" }
     // ] },
-    { label: "Mnemonics", symbol: "mnemonics", placeholder: "Enter Your Polkadot Mnemonics or TFChain secret", type: "password" },
+    { label: "Mnemonics", symbol: "mnemonics", placeholder: "Enter Your Polkadot Mnemonics", type: "password" },
     // { label: "TFChain Configurations Secret", symbol: "storeSecret", placeholder: "  Secret key used to encrypt your data on TFChain", type: "password" },
     { label: "Public SSH Key", symbol: "sshKey", placeholder: "Your public SSH key will be added as default to all deployments.", type: "text" },
   ];


### PR DESCRIPTION
### Description

as required in threefoldtech/tfgrid-sdk-ts#127, and the [comment](https://github.com/threefoldtech/tfgrid-sdk-ts/issues/127), TFChain secret removed from the placeholder.

### Changes

remove _TFChain secret_  from the Mnemonics placeholder to be : " _Enter Your Polkadot Mnemonics_ " only.
### Related Issues

List of related issues

threefoldtech/tfgrid-sdk-ts#127
