### PR TITLE
make deploy btn disabled while ping node

### DIFF
--- a/src/components/SelectNodeId.svelte
+++ b/src/components/SelectNodeId.svelte
@@ -348,12 +348,14 @@
 
   async function pingNode(node: number) {
     if (node && status == "valid") {
-      let grid = await getGrid(profile, grid => grid, false);
+      let grid = await getGrid(profile, grid => grid);
       try {
+        status = null;
         validating = true;
         await grid.zos.pingNode({ nodeId: node });
         aliveNode = true;
         validating = false;
+        status = "valid";
         return true;
       } catch (e) {
         nodeIdField.disabled = validating = false;


### PR DESCRIPTION
### Description

set status to null while pinging node, and if the node is up set it again to valid,
remove unnecessary args in getClient

![image](https://user-images.githubusercontent.com/62248851/209562539-863a8028-bcba-4e07-a78f-7f73c6d811ef.png)


### Related Issues
deploy button is enabled while validating the node #1182

### Checklist
- [x] Build pass

