### PR TITLE
Adding the Mattermost domain to the data modal

### DIFF
--- a/src/components/FormatData.svelte
+++ b/src/components/FormatData.svelte
@@ -136,4 +136,15 @@
       }}
     />
   {/if}
+  {#if vm.env.MATTERMOST_DOMAIN}
+    <Input
+      data={"https://" + vm.env.MATTERMOST_DOMAIN}
+      field={{
+        label: "Domain",
+        symbol: "domain",
+        type: "text",
+        disabled: true,
+      }}
+    />
+  {/if}
 {/if}

--- a/src/utils/deployMattermost.ts
+++ b/src/utils/deployMattermost.ts
@@ -53,6 +53,7 @@ function _deployMatterMost(profile: IProfile, mattermost: Mattermost) {
     SMTPServer: server,
     SMTPPort: port,
     SSH_KEY: profile.sshKey,
+    MATTERMOST_DOMAIN: domain,
   };
 
   const vms = new MachinesModel();


### PR DESCRIPTION
### Description

Adding the mattermost domain to  name the data modal
### Changes

Adding a MATTERMOST_DOMAIN env var and adding it to the data modal after deploying a Mattermost instance.
### Related Issues

#1266 
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
