### PR TITLE
disable nodeSelectionFeild while pinging node

### DIFF
--- a/src/components/SelectNodeId.svelte
+++ b/src/components/SelectNodeId.svelte
@@ -301,9 +301,7 @@
               return node["nodeId"];
             })
             .then(async (node: any) => {
-              nodeIdField.disabled = validating = node;
               await pingNode(node);
-              nodeIdField.disabled = validating = false;
             })
             .catch((err: Error) => {
               console.log("Error", err);
@@ -352,14 +350,14 @@
       let grid = await getGrid(profile, grid => grid);
       try {
         status = null;
-        validating = true;
+        nodeIdField.disabled = nodeSelectionField.disabled = validating = true;
         await grid.zos.pingNode({ nodeId: node });
         aliveNode = true;
-        validating = false;
+        nodeIdField.disabled = nodeSelectionField.disabled = validating = false;
         status = "valid";
         return true;
       } catch (e) {
-        nodeIdField.disabled = validating = false;
+        nodeIdField.disabled = nodeSelectionField.disabled = validating = false;
         status = "down";
         aliveNode = false;
         return false;


### PR DESCRIPTION
### Description

while pingNode the selection type field is now disabled to prevent the user from changing type while pinging the node 
![image](https://user-images.githubusercontent.com/62248851/216021216-b1b53558-8dd4-4b6f-b533-4b8b07aed691.png)

### Changes
set ` nodeIdField.disabled` and  `nodeSelectionField.disabled` to false or true inside `pingNode` function 

### Related Issues

- #1277

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
