### PR TITLE
Adding required env vars to the helm chart

### DIFF
--- a/weblets-chart/templates/deployment.yaml
+++ b/weblets-chart/templates/deployment.yaml
@@ -33,6 +33,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          {{- range $key, $val := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 80

--- a/weblets-chart/values.yaml
+++ b/weblets-chart/values.yaml
@@ -9,6 +9,24 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
+  
+  env:
+    - name: "MODE"
+      value: ""
+    - name: "GRAPHQL_URL"
+      value: ""
+    - name: "BRIDGE_TFT_ADDRESS"
+      value: ""
+    - name: "GRIDPROXY_URL"
+      value: ""
+    - name: "SUBSTRATE_URL"
+      value: ""
+    - name: "ACTIVATION_SERVICE_URL"
+      value: ""
+    - name: "RELAY_DOMAIN"
+      value: ""
+    - name: "STELLAR_NETWORK"
+      value: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
### Description

Adding env vars to the helm chart

### Changes

- Adding the required env vars to `values.yaml`
  - MODE  
  - STELLAR_NETWORK
  - GRAPHQL_URL
  - BRIDGE_TFT_ADDRESS
  - GRIDPROXY_URL
  - SUBSTRATE_URL
  - ACTIVATION_SERVICE_URL
  - RELAY_DOMAIN
- modifying the deployment template to read env vars from `values.yaml` file

### Related Issues

https://github.com/threefoldtech/tf_operations/issues/1495

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
