### PR TITLE
Remove grid from onMount & Return it back from deployCaprover

### DIFF
--- a/src/elements/caprover/Caprover.wc.svelte
+++ b/src/elements/caprover/Caprover.wc.svelte
@@ -22,8 +22,6 @@
   import SelectCapacity from "../../components/SelectCapacity.svelte";
   import AddBtn from "../../components/AddBtn.svelte";
   import DeleteBtn from "../../components/DeleteBtn.svelte";
-  import { onMount } from "svelte";
-  import getGrid from "../../utils/getGrid";
   import { display } from "../../utils/display";
   import normalizeDeploymentErrorMessage from "../../utils/normalizeDeploymentErrorMessage";
 
@@ -35,7 +33,6 @@
   let profile: IProfile;
   let status: "valid" | "invalid";
   const currentDeployment = window.configs?.currentDeploymentStore;
-  let grid;
 
   // prettier-ignore
   const tabs: ITab[] = [
@@ -84,7 +81,7 @@
     message = undefined;
 
     deployCaprover(data, profile)
-      .then(async () => {
+      .then(async grid => {
         let vms = await grid.machines.getObj(data.name);
         success = true;
         modalData = vms;
@@ -92,7 +89,7 @@
 
         vms.forEach(machine => {
           let firstWorker = true;
-          if (machine.env["SWM_NODE_MODE"] == "worker") {
+          if (machine && machine.env["SWM_NODE_MODE"] == "worker") {
             if (firstWorker) {
               workerIp += machine.publicIP["ip"].split("/")[0] + ", ";
               firstWorker = false;
@@ -119,12 +116,6 @@
   $: showSuccess = !showLogs && !showNoProfile && success;
   $: showFailed = !showLogs && !showNoProfile && failed;
   $: showContent = !showLogs && !showNoProfile && !showSuccess && !showFailed;
-
-  onMount(async () => {
-    grid = await getGrid(profile, grid => grid, false);
-    grid.projectName = "caprover";
-    grid._connect();
-  });
 </script>
 
 <SelectProfile

--- a/src/utils/deployCaprover.ts
+++ b/src/utils/deployCaprover.ts
@@ -90,6 +90,7 @@ export default async function deployCaprover(data: Caprover, profile: IProfile) 
     return grid.machines
       .deploy(machines)
       .then(() => grid.machines.getObj(name))
-      .then(([vm]) => vm);
+      .then(([vm]) => vm)
+      .then(() => grid);
   });
 }


### PR DESCRIPTION
### Description

Use a single grid instance for CapRover deployment

### Changes

Instead of getting a new grid instance on page load, use the grid instance from the deploy script.

### Related Issues

https://github.com/threefoldtech/grid_weblets/issues/1389

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
