### PR TITLE
Resolve some namespace related issues

### DIFF
--- a/src/components/SelectNodeId.svelte
+++ b/src/components/SelectNodeId.svelte
@@ -346,7 +346,7 @@
 
   async function pingNode(node: number) {
     if (node && status == "valid") {
-      let grid = await getGrid(profile, grid => grid);
+      let grid = await getGrid(profile, grid => grid, "");
       try {
         status = null;
         nodeIdField.disabled = nodeSelectionField.disabled = validating = true;

--- a/src/components/UpdateCapRover.svelte
+++ b/src/components/UpdateCapRover.svelte
@@ -66,9 +66,7 @@
     worker.publicKey = capRover.details.env.PUBLIC_KEY;
     domain = capRover.details.env.CAPROVER_ROOT_DOMAIN;
 
-    grid = await getGrid(profile, grid => grid, false);
-    grid.projectName = "caprover";
-    grid._connect();
+    grid = await getGrid(profile, grid => grid, "CapRover");
 
     if (capRover)
       workers = (await grid.machines.getObj(capRover["name"])).filter(

--- a/src/components/UpdateK8s.svelte
+++ b/src/components/UpdateK8s.svelte
@@ -57,48 +57,52 @@
   function onAddWorker() {
     loading = true;
     currentDeployment.deploy("Add Worker", worker.name);
-    getGrid(profile, grid => {
-      const { name, cpu, memory, diskSize, publicIp, publicIp6,planetary, node, rootFs } = worker; // prettier-ignore
-      const workerModel = new AddWorkerModel();
-      workerModel.deployment_name = k8s.name;
-      workerModel.name = name;
-      workerModel.cpu = cpu;
-      workerModel.memory = memory;
-      workerModel.disk_size = diskSize;
-      workerModel.public_ip = publicIp;
-      workerModel.public_ip6 = publicIp6;
-      workerModel.planetary = planetary;
-      workerModel.rootfs_size = rootFs;
-      workerModel.node_id = node;
-      workerModel.solutionProviderID = InternalSolutionProviderID;
+    getGrid(
+      profile,
+      grid => {
+        const { name, cpu, memory, diskSize, publicIp, publicIp6,planetary, node, rootFs } = worker; // prettier-ignore
+        const workerModel = new AddWorkerModel();
+        workerModel.deployment_name = k8s.name;
+        workerModel.name = name;
+        workerModel.cpu = cpu;
+        workerModel.memory = memory;
+        workerModel.disk_size = diskSize;
+        workerModel.public_ip = publicIp;
+        workerModel.public_ip6 = publicIp6;
+        workerModel.planetary = planetary;
+        workerModel.rootfs_size = rootFs;
+        workerModel.node_id = node;
+        workerModel.solutionProviderID = InternalSolutionProviderID;
 
-      grid.k8s
-        .add_worker(workerModel)
-        .then(({ contracts }) => {
-          const { updated } = contracts;
-          if (updated.length > 0) {
-            success = true;
-            shouldBeUpdated = true;
-            worker = new Worker();
-            return grid.k8s.getObj(k8s.name);
-          } else {
+        grid.k8s
+          .add_worker(workerModel)
+          .then(({ contracts }) => {
+            const { updated } = contracts;
+            if (updated.length > 0) {
+              success = true;
+              shouldBeUpdated = true;
+              worker = new Worker();
+              return grid.k8s.getObj(k8s.name);
+            } else {
+              failed = true;
+            }
+          })
+          .then(data => {
+            if (!data) return;
+            workers = data.workers;
+          })
+          .catch(err => {
             failed = true;
-          }
-        })
-        .then(data => {
-          if (!data) return;
-          workers = data.workers;
-        })
-        .catch(err => {
-          failed = true;
-          console.log("Error", err);
-          message = err.message || err;
-        })
-        .finally(() => {
-          loading = false;
-          currentDeployment.clear();
-        });
-    });
+            console.log("Error", err);
+            message = err.message || err;
+          })
+          .finally(() => {
+            loading = false;
+            currentDeployment.clear();
+          });
+      },
+      "Kubernetes",
+    );
   }
 
   function onDeleteWorker(idx: number) {
@@ -106,34 +110,38 @@
     removing = worker.name;
     loading = true;
     currentDeployment.deploy("Remove Worker", worker.name);
-    getGrid(profile, grid => {
-      const workerModel = new DeleteWorkerModel();
-      workerModel.deployment_name = k8s.name;
-      workerModel.name = removing;
-      grid.k8s
-        .delete_worker(workerModel)
-        .then(({ deleted, updated }) => {
-          if (deleted.length > 0 || updated.length > 0) {
-            shouldBeUpdated = true;
-            let r = removing;
-            requestAnimationFrame(() => {
-              workers = workers.filter(({ name }) => name !== r); // prettier-ignore
-            });
-          } else {
-            failed = true;
-            message = "Failed to remove worker";
-          }
-        })
-        .catch(err => {
-          console.log("Error", err);
-          message = err.message || err;
-        })
-        .finally(() => {
-          loading = false;
-          removing = null;
-          currentDeployment.clear();
-        });
-    });
+    getGrid(
+      profile,
+      grid => {
+        const workerModel = new DeleteWorkerModel();
+        workerModel.deployment_name = k8s.name;
+        workerModel.name = removing;
+        grid.k8s
+          .delete_worker(workerModel)
+          .then(({ deleted, updated }) => {
+            if (deleted.length > 0 || updated.length > 0) {
+              shouldBeUpdated = true;
+              let r = removing;
+              requestAnimationFrame(() => {
+                workers = workers.filter(({ name }) => name !== r); // prettier-ignore
+              });
+            } else {
+              failed = true;
+              message = "Failed to remove worker";
+            }
+          })
+          .catch(err => {
+            console.log("Error", err);
+            message = err.message || err;
+          })
+          .finally(() => {
+            loading = false;
+            removing = null;
+            currentDeployment.clear();
+          });
+      },
+      "Kubernetes",
+    );
   }
 
   const style = `

--- a/src/elements/DeployedList/DeployedList.wc.svelte
+++ b/src/elements/DeployedList/DeployedList.wc.svelte
@@ -19,7 +19,7 @@
   import DialogueMsg from "../../components/DialogueMsg.svelte";
   import getGrid from "../../utils/getGrid";
   import type { IStore } from "../../stores/currentDeployment";
-
+  import type { GridClient } from "grid3_client";
   type TabsType = IStore["type"];
   export let tab: TabsType = undefined;
 
@@ -45,7 +45,7 @@
     { label: "Umbrel", value: "Umbrel" },
     { label: "Wordpress", value: "Wordpress" },
   ];
-  let grid;
+  let grid: GridClient;
   let active: IStore["type"] = "VM";
   $: active = tab || active;
 
@@ -112,7 +112,7 @@
       _reloadTab();
     });
     if (profile) {
-      grid = await getGrid(profile, grid => grid, false);
+      grid = await getGrid(profile, grid => grid, "");
     }
   });
 
@@ -174,7 +174,7 @@
           type: "info",
           label: "Show Details",
           click: async (_, i) => {
-            grid.projectName = active;
+            grid.clientOptions.projectName = active;
             grid._connect();
             infoToShow = await grid.machines.getObj(rows[i]["name"]);
           },

--- a/src/types/deployedList.ts
+++ b/src/types/deployedList.ts
@@ -73,7 +73,7 @@ export default class DeployedList {
     const deps1 = await this.loadK8sDeployment("");
 
     const deps2 = await this.loadK8sDeployment("k8s");
-    
+
     const deps3 = await this.loadK8sDeployment("Kubernetes");
 
     return {
@@ -144,17 +144,17 @@ export default class DeployedList {
     if (!type) return this.loadVm();
 
     /**
-     * Deployments of the same type can be in 
-     */  
-   
+     * Deployments of the same type can be in
+     */
+
     // 1. default namespace: filtered by the project name in the flist
     const deps1 = await this.loadVm().then(vms => {
       return vms.data.filter(vm => vm.flist.toLowerCase().includes(type.toLowerCase()));
     });
-    
+
     // 2. uppercase project name as namespace.
     const deps2 = await this.loadVm(type);
-    
+
     // 3. lowercase project name as namespace.
     const deps3 = await this.loadVm(type.toLowerCase());
 
@@ -165,7 +165,7 @@ export default class DeployedList {
   }
 
   public static async init(profile: IProfile): Promise<DeployedList> {
-    return new DeployedList(await getGrid(profile, grid => grid));
+    return new DeployedList(await getGrid(profile, grid => grid, ""));
   }
 
   public static __filterNames(names: string[]): string[] {

--- a/src/types/profileManager.ts
+++ b/src/types/profileManager.ts
@@ -20,7 +20,7 @@ export const mnemonics = fb.control<string>(
   [
     async ctrl => {
       try {
-        await getGrid({ networkEnv, mnemonics: ctrl.value } as any, _ => _);
+        await getGrid({ networkEnv, mnemonics: ctrl.value } as any, _ => _, "");
       } catch (e) {
         return { message: e.message };
       }
@@ -58,7 +58,7 @@ export function getTwinAndAddress(mnemonics: string): Promise<GetTwinAndAddress 
     return Promise.resolve(getTwinAndAddressData.get(mnemonics));
   }
 
-  return getGrid({ networkEnv, mnemonics } as any, _ => _)
+  return getGrid({ networkEnv, mnemonics } as any, _ => _, "")
     .then(grid => Promise.all([Promise.resolve(grid), grid.twins.get_my_twin_id()]))
     .then(([grid, twinId]) => {
       getTwinAndAddressData.set(mnemonics, { twinId, address: grid.twins.client.client.address });
@@ -68,7 +68,7 @@ export function getTwinAndAddress(mnemonics: string): Promise<GetTwinAndAddress 
 }
 
 export function readSSH(mnemonics: string): Promise<string> {
-  return getGrid({ networkEnv, mnemonics } as any, _ => _)
+  return getGrid({ networkEnv, mnemonics } as any, _ => _, "")
     .then(grid => {
       return grid;
     })
@@ -84,7 +84,7 @@ export function storeSSH(mnemonics: string, ssh: string): Promise<boolean> {
   return readSSH(mnemonics)
     .then(oldSsh => {
       if (ssh === oldSsh) return true;
-      return getGrid({ networkEnv, mnemonics } as any, _ => _)
+      return getGrid({ networkEnv, mnemonics } as any, _ => _, "")
         .then(grid => grid.kvstore.set({ key: "metadata", value: metadata }))
         .then(() => true);
     })
@@ -109,8 +109,8 @@ async function resolve<T>(promise: Promise<T>): Promise<[T, Error]> {
 }
 
 export async function migrate(mnemonics: string, storeSecret: string) {
-  const oldClient = await getGrid({ networkEnv, mnemonics, storeSecret } as any, _ => _); // prettier-ignore
-  const newClient = await getGrid({ networkEnv, mnemonics } as any, _ => _); // prettier-ignore
+  const oldClient = await getGrid({ networkEnv, mnemonics, storeSecret } as any, _ => _, ""); // prettier-ignore
+  const newClient = await getGrid({ networkEnv, mnemonics } as any, _ => _,""); // prettier-ignore
 
   const oldDB = oldClient.kvstore;
   const newDB = newClient.kvstore;
@@ -170,7 +170,7 @@ export function generateSSH(mnemonics: string) {
     size: 4096,
   })
     .then(_keys => (keys = _keys))
-    .then(() => getGrid({ networkEnv, mnemonics } as any, _ => _))
+    .then(() => getGrid({ networkEnv, mnemonics } as any, _ => _, ""))
     .then(grid => grid.kvstore.set({ key: "metadata", value: JSON.stringify({ sshkey: keys.publicKey }) }))
     .then(() => {
       const data = `data:text/raw;charset=utf-8,${encodeURIComponent(keys.privateKey)}`;

--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -22,7 +22,6 @@ export default function deploy<T>(
           window.configs.currentDeploymentStore.clear();
         });
     },
-    true,
     type,
   );
 }

--- a/src/utils/deployQVM.ts
+++ b/src/utils/deployQVM.ts
@@ -35,7 +35,7 @@ export default function deployQvm(vm: VM, QSFS: QSFS, profile: IProfile) {
         });
     });
   } catch (err) {
-    getGrid(profile, grid => grid).then(async grid => {
+    getGrid(profile, grid => grid, "Qvm").then(async grid => {
       await grid.qsfs_zdbs.delete(qsfs);
       throw err;
     });

--- a/src/utils/getBalance.ts
+++ b/src/utils/getBalance.ts
@@ -12,5 +12,6 @@ export default async function getBalance(profile: Profile) {
       .getMyBalance()
       .then((res) => res);
     },
+    "",
   );
 }

--- a/src/utils/getContractsConsumption.ts
+++ b/src/utils/getContractsConsumption.ts
@@ -21,7 +21,11 @@ function _getConsumption(id: number, grid: GridClient) {
 }
 
 export default function getContractsConsumption(profile: IProfile, contracts: { id: number }[]) {
-  return getGrid(profile, grid => {
-    return Promise.all(contracts.map(({ id }) => _getConsumption(+id, grid)));
-  });
+  return getGrid(
+    profile,
+    grid => {
+      return Promise.all(contracts.map(({ id }) => _getConsumption(+id, grid)));
+    },
+    "",
+  );
 }

--- a/src/utils/getGrid.ts
+++ b/src/utils/getGrid.ts
@@ -1,11 +1,11 @@
 import type { IProfile } from "../types/Profile";
 import type { GridClient } from "grid3_client";
+import type { IStore } from "../types/istore";
 
 export default async function getGrid<T>(
   profile: IProfile,
   cb: (grid: GridClient) => T,
-  disconnect = true,
-  solutionType?: string,
+  solutionType: IStore["type"] | "",
 ): Promise<T> {
   const { mnemonics } = profile;
   const grid = new window.configs.grid3_client.GridClient({


### PR DESCRIPTION
### Description

we need to pass the solution type in every call of grid, some functions that use getGrid directly don't 
### Changes

- remove `disconnect` in getGrid as it is no more needed 
- set SolutionType as required 
- update the way of set  `projectName` to use `ClientOptions"
- in the calls of `getGrid` that have no specific solution type like node filter, I set the solutionType to be `""` 

### Related Issues

- https://github.com/threefoldtech/grid_weblets/issues/1410

### Checklist

- [x] Tested k8t deploy, update, and delete, also delete contracts
> I couldn't test caprover as there no free public ip
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
