### PR TITLE
fix virtual machine deploy disk filtering

### DIFF
--- a/src/elements/fullvm/Fullvm.wc.svelte
+++ b/src/elements/fullvm/Fullvm.wc.svelte
@@ -128,6 +128,7 @@
     invalid: false,
   };
 
+  $: data.disks[0].size = data.diskSize;
   async function onDeployVM() {
     if (flistSelectValue === "other") {
       validateFlist.loading = true;


### PR DESCRIPTION
### Description

Fix virtual machine deploy disk filtering

### Changes

Fixed a bug where disk size filtering was always done with a constant value regardless of the user's input.

### Related Issues

https://github.com/threefoldtech/grid_weblets/issues/1133

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
