### PR TITLE
fix disk field in select capacity

### DIFF
--- a/src/elements/discourse/Discourse.wc.svelte
+++ b/src/elements/discourse/Discourse.wc.svelte
@@ -160,7 +160,7 @@
               const { cpu, memory, diskSize } = detail.package;
               data.cpu = cpu;
               data.memory = memory;
-              data.disks[0].size = diskSize;
+              data.diskSize = diskSize;
             }
           }}
         />

--- a/src/elements/umbrel/umbrel.wc.svelte
+++ b/src/elements/umbrel/umbrel.wc.svelte
@@ -22,6 +22,7 @@
   import { noActiveProfile } from "../../utils/message";
   import SelectCapacity from "../../components/SelectCapacity.svelte";
   import normalizeDeploymentErrorMessage from "../../utils/normalizeDeploymentErrorMessage";
+  import rootFs from "../../utils/rootFs";
 
   let data = new Umbrel();
   data.disks = [new Disk()];
@@ -175,7 +176,7 @@
         cpu={data.cpu}
         memory={data.memory}
         publicIp={data.publicIp}
-        ssd={data.disks.reduce((total, disk) => total + disk.size + 10, 0)}
+        ssd={data.diskSize + 10 + rootFs(data.cpu, data.memory)}
         bind:data={data.nodeId}
         bind:nodeSelection={data.selection.type}
         bind:status

--- a/src/elements/umbrel/umbrel.wc.svelte
+++ b/src/elements/umbrel/umbrel.wc.svelte
@@ -167,7 +167,7 @@
             const { cpu, memory, diskSize } = detail.package;
             data.cpu = cpu;
             data.memory = memory;
-            data.disks[0].size = diskSize;
+            data.diskSize = diskSize;
           }
         }}
       />

--- a/src/elements/wordpress/wordpress.wc.svelte
+++ b/src/elements/wordpress/wordpress.wc.svelte
@@ -178,7 +178,7 @@
             const { cpu, memory, diskSize } = detail.package;
             data.cpu = cpu;
             data.memory = memory;
-            data.disks[0].size = diskSize;
+            data.diskSize = diskSize;
           }
         }}
       />

--- a/src/elements/wordpress/wordpress.wc.svelte
+++ b/src/elements/wordpress/wordpress.wc.svelte
@@ -24,6 +24,7 @@
   import type { GatewayNodes } from "../../utils/gatewayHelpers";
   import SelectCapacity from "../../components/SelectCapacity.svelte";
   import normalizeDeploymentErrorMessage from "../../utils/normalizeDeploymentErrorMessage";
+  import rootFs from "../../utils/rootFs";
 
   let data = new Wordpress();
   data.disks = [new Disk()];
@@ -187,7 +188,7 @@
         cpu={data.cpu}
         memory={data.memory}
         publicIp={false}
-        ssd={data.disks.reduce((total, disk) => total + disk.size, 0)}
+        ssd={data.diskSize + rootFs(data.cpu, data.memory)}
         bind:data={data.nodeId}
         bind:nodeSelection={data.selection.type}
         bind:status


### PR DESCRIPTION
### Description

The `data.diskSize` is not updated, but `data.disks[0].size` is while the solutions have no disks

### Changes

- update `data.diskSize` 
- update the way of calculating sru 

### Related Issues

- #1428 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
