### PR TITLE
avoid null result after pingnode

### DIFF
--- a/src/components/SelectNodeId.svelte
+++ b/src/components/SelectNodeId.svelte
@@ -356,7 +356,7 @@
         await grid.zos.pingNode({ nodeId: node });
         aliveNode = true;
         nodeIdField.disabled = nodeSelectionField.disabled = validating = false;
-        if (data) status = "valid";
+        if (data && status !== "invalid") status = "valid";
         return true;
       } catch (e) {
         nodeIdField.disabled = nodeSelectionField.disabled = validating = false;

--- a/src/components/SelectNodeId.svelte
+++ b/src/components/SelectNodeId.svelte
@@ -356,7 +356,7 @@
         await grid.zos.pingNode({ nodeId: node });
         aliveNode = true;
         nodeIdField.disabled = nodeSelectionField.disabled = validating = false;
-        status = "valid";
+        if (data) status = "valid";
         return true;
       } catch (e) {
         nodeIdField.disabled = nodeSelectionField.disabled = validating = false;


### PR DESCRIPTION
### Description

if the user change any values while pinging the node and there is no available nodes, we will see node (null) up,
as mentioned in this [comment](https://github.com/threefoldtech/grid_weblets/issues/1358#issuecomment-1501098997)

### Changes

just check on the values of `data`, on capacity filter if there is no available nodes the `data` will be null 
in manual filter , if the entered node id is not available the `status = invalid` 

### Related Issues

- #1358 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
