### PR TITLE
set umbrel password upper limit 

### DIFF
--- a/src/utils/validateName.ts
+++ b/src/utils/validateName.ts
@@ -163,6 +163,7 @@ export function validatePassword(value: string): string | void {
 export function validateUmbrelPassword(value: string): string | void {
   if (value == "") return "Password is required";
   if (value.length < 12) return "Password must be at least 12";
+  if (value.length > 30) return "Password must be at most 30 characters";
 }
 
 export function validateRequiredPassword(value: string): string | void {


### PR DESCRIPTION
### Description

Describe the changes introduced by this PR and what does it affect

### Changes

add upper  limit to `validateUmbrelPassword` to be 30 chat at most 

### Related Issues

- #1360 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
